### PR TITLE
ci: add merge-based nightly sync

### DIFF
--- a/.github/workflows/fork-nightly-merge-sync.yml
+++ b/.github/workflows/fork-nightly-merge-sync.yml
@@ -1,0 +1,150 @@
+name: Fork Nightly Merge Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch to merge into (default: main)'
+        required: false
+        default: 'main'
+      sync_branch:
+        description: 'Sync branch name (default: automation/nightly-upstream-merge)'
+        required: false
+        default: 'automation/nightly-upstream-merge'
+      upstream_repo:
+        description: 'Upstream repository (default: microsoft/vscode-copilot-chat)'
+        required: false
+        default: 'microsoft/vscode-copilot-chat'
+      upstream_branch:
+        description: 'Upstream branch to merge from (default: main)'
+        required: false
+        default: 'main'
+      conflict_strategy:
+        description: 'Conflict handling mode'
+        required: false
+        type: choice
+        default: 'commit'
+        options:
+          - commit
+          - report
+      dry_run:
+        description: 'Dry run mode - stop before pushing'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: '15 2 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge_sync:
+    runs-on: ubuntu-latest
+    environment: develop
+    outputs:
+      sync_outcome: ${{ steps.capture_metadata.outputs.sync_outcome }}
+      pr_number: ${{ steps.capture_metadata.outputs.pr_number }}
+      pr_url: ${{ steps.capture_metadata.outputs.pr_url }}
+    env:
+      MERGE_LOG_PATH: ''
+      PR_URL: ''
+      PR_NUMBER: ''
+      SYNC_OUTCOME: ''
+      UPSTREAM_LOG_PATH: ''
+      CONFLICT_REPORT_PATH: ''
+      SYNC_LOG_DIR: ''
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.ref }}
+
+      - name: Configure Git credentials for pushes
+        run: git remote set-url origin https://$GH_TOKEN@github.com/${{ github.repository }}.git
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Configure Git LFS fetch options
+        run: ./script/setup-lfs-config.sh
+
+      - name: Nightly upstream merge sync
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          TARGET_BRANCH: ${{ inputs.target_branch || 'main' }}
+          SYNC_BRANCH: ${{ inputs.sync_branch || 'automation/nightly-upstream-merge' }}
+          UPSTREAM_REPO: ${{ inputs.upstream_repo || 'microsoft/vscode-copilot-chat' }}
+          UPSTREAM_BRANCH: ${{ inputs.upstream_branch || 'main' }}
+          MERGE_CONFLICT_MODE: ${{ inputs.conflict_strategy || 'commit' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: ./script/sync-fork-merge.sh
+
+      - name: Capture sync metadata
+        id: capture_metadata
+        run: |
+          echo "sync_outcome=${SYNC_OUTCOME:-}" >>"$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER:-}" >>"$GITHUB_OUTPUT"
+          echo "pr_url=${PR_URL:-}" >>"$GITHUB_OUTPUT"
+
+      - name: Upload sync logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-merge-sync-logs
+          path: ${{ env.SYNC_LOG_DIR != '' && env.SYNC_LOG_DIR || '.github/tmp/sync-logs' }}
+          if-no-files-found: ignore
+
+      - name: Append job summary
+        if: always()
+        shell: bash
+        env:
+          DRY_RUN_INPUT: ${{ inputs.dry_run || 'false' }}
+          TARGET_BRANCH: ${{ inputs.target_branch || 'main' }}
+          SYNC_BRANCH: ${{ inputs.sync_branch || 'automation/nightly-upstream-merge' }}
+          UPSTREAM_REPO: ${{ inputs.upstream_repo || 'microsoft/vscode-copilot-chat' }}
+          UPSTREAM_BRANCH: ${{ inputs.upstream_branch || 'main' }}
+          CONFLICT_STRATEGY: ${{ inputs.conflict_strategy || 'commit' }}
+        run: |
+          {
+            echo "### Fork Nightly Merge Sync"
+            echo ""
+            if [ "${DRY_RUN_INPUT}" = "true" ]; then
+              echo "⚠️ **Dry run mode**: Commands ran locally, push/PR were skipped."
+              echo ""
+            fi
+            echo "**Configuration:**"
+            echo "* Target branch: ${TARGET_BRANCH}"
+            echo "* Sync branch: ${SYNC_BRANCH}"
+            echo "* Upstream repo: ${UPSTREAM_REPO}"
+            echo "* Upstream branch: ${UPSTREAM_BRANCH}"
+            echo "* Conflict strategy: ${CONFLICT_STRATEGY}"
+            echo "* Triggered from: ${GITHUB_REF}"
+            echo ""
+            echo "**Result:**"
+            echo "* Outcome: ${SYNC_OUTCOME:-unknown}"
+            if [ -n "${PR_URL:-}" ]; then
+              echo "* PR: ${PR_URL}"
+            fi
+            if [ -n "${MERGE_LOG_PATH:-}" ]; then
+              echo "* Merge log: ${MERGE_LOG_PATH}"
+            fi
+            if [ -n "${UPSTREAM_LOG_PATH:-}" ] && [ -f "${UPSTREAM_LOG_PATH}" ]; then
+              echo ""
+              echo "**Upstream commits:**"
+              sed 's/^/- /' "${UPSTREAM_LOG_PATH}"
+            fi
+            if [ -n "${CONFLICT_REPORT_PATH:-}" ] && [ -f "${CONFLICT_REPORT_PATH}" ]; then
+              echo ""
+              echo "**Conflict report:**"
+              cat "${CONFLICT_REPORT_PATH}"
+            fi
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/docs/merge-sync-lfs-investigation.md
+++ b/docs/merge-sync-lfs-investigation.md
@@ -1,0 +1,27 @@
+# Merge Sync + Git LFS Investigation
+
+## Summary
+- Merge-based nightly workflow failed with `GH008` even after stripping cache files.
+- The merge helper removes `test/simulation/cache/**/*.sqlite` from each merge commit, but GitHub validates **all** parents: upstream commits still reference cache layers.
+- Because this repo was not a registered fork of `microsoft/vscode-copilot-chat`, GitHub's LFS store did not contain those upstream blobs, so pushes were rejected unless we uploaded them ourselves.
+- Now that `origin` is a true fork, GitHub can reuse upstream LFS objects once the workflow lands here. Before the conversion, the only alternatives were uploading the blobs (breaking pointer-only policy) or squashing history.
+
+## Evidence
+1. Local dry-run merges show no `.sqlite` files (`git ls-tree -r automation/nightly-merge-debug | grep ".sqlite"` yields nothing).
+2. Remote push still failed with:
+   ```
+   Git LFS upload missing objects:
+     (missing) test/simulation/cache/layers/c451045a-da8c-43fa-ba6f-8198c2eb0975.sqlite (0349…)
+     (missing) test/simulation/cache/layers/70406ad0-1fbd-47a0-9b72-6b80e3b3d46b.sqlite (d4ec…)
+   remote: error: GH008: Your push referenced at least 2 unknown Git LFS objects
+   ```
+3. `gh repo view --json isFork,parent` returned `isFork: false` before the conversion, confirming GitHub had no linkage to upstream's LFS store.
+
+## Options Considered
+1. **Upload missing blobs** – fetch upstream cache layers via `git lfs fetch upstream main --include='test/simulation/cache/**/*.sqlite'` and push them. This works but breaks the pointer-only fork policy and consumes LFS quota.
+2. **Convert the repo into a genuine fork (chosen)** – either recreate via the Fork button or ask GitHub Support to convert/copy LFS objects. Once GitHub recognizes the fork relationship, merge commits referencing upstream blobs push cleanly.
+3. **Return to squash merges** – avoid pushing upstream commits entirely. This keeps the fork pointer-only but loses upstream history and accurate summaries.
+
+## Next Steps
+- Keep this doc as a reference for why the workflow must run on a real fork.
+- Proceed with replaying custom commits (see `docs/unique-fork-commits.txt`). Start with workflow/automation changes, then reintroduce product logic in well-scoped batches via `git cherry-pick` or `git format-patch`.

--- a/docs/unique-fork-commits.txt
+++ b/docs/unique-fork-commits.txt
@@ -1,0 +1,91 @@
+6e677e86 Merge pull request #61 from yulongbai-nov/feature/restore-merge-nightly-sync
+d15c1481 Restore merge-based nightly sync
+f390091f remove .lfsconfig
+6c98192c ci: remove Copilot maintenance delegate workflow and script; tighten fork-nightly-squash-sync permissions
+f2e20db2 ci: use PAT for origin pushes (#0)
+af9c760c Chore/cache hydration squash (#52)
+d806a628 Align hydration flow with squash sync (#51)
+060ef0c6 Nightly upstream merge (61247052) (#50)
+2ef10235 tests: await snapshot matchers (#49)
+f210d7c2 prompt-visualizer: tighten typing (#48)
+3beb0f92 Fix/sync script lfs (#46)
+e545c5ad automation: merge upstream via git merge
+8435119b docs: document disabled LFS hydration
+386ae095 config: fix prompt visualizer settings
+4f56fc99 tools: remove runSubagent import
+89eff308 Fix/nightly sync lfs pointer only (#43)
+3869e376 ci: disable cache guard workflow
+deb385f4 chore(sync): strip simulation cache artifacts before pushing
+a4d72711 chore(cache): hydrate pointers from upstream before checkout
+ffb00319 docs: record pointer-only cache workflow
+c2e0553b chore(cache): stop tracking simulation cache blobs
+5125bc05 fix: Document pointer-only workflow for Git LFS in simulation cache guide and sync script
+869e4ffd fix: Simplify nightly merge to only push LFS pointers, not objects
+d2df1709 Replace GITHUB_TOKEN with GH_TOKEN in workflows
+987bb524 fix: Add fetch-depth: 0 to all remaining workflows using hydrateSimulationCache.ts
+e74e6d49 fix: Add fetch-depth: 0 to all jobs using hydrateSimulationCache.ts
+d01c71dc ci: Re-enable all test jobs after debugging fixes
+11601318 debug: Add detailed error logging for all git commands in hydration script
+410da8a5 fix: Use fetch-depth: 0 to enable git merge-base with upstream
+c35df1de fix: Detect and hydrate LFS pointer files instead of skipping them
+5b06fd34 debug: Add detailed logging for cache hydration and validation
+01d5b956 simulation-cache: hydrate via merge-base helper (#37)
+050b52cb promptSectionVisualizer: accept vscode.Command in mock stream; add render mode configs
+8c571c89 workflows: add manual dispatch triggers (#32)
+e1a5d1d2 workflows: fix nightly merge env warnings
+053cc5ee endpoint: fix responses api typings
+02cbc40c endpoint: fix responses api typings
+5234c397 docs: mark task 9.6 as completed in spec
+4bb67ace docs: add E2E test plan and simulation cache guide
+fe6cee88 test: update existing tests for deprecated WebView and chat integration
+5de6bf88 test: add comprehensive tests for native Chat API components
+2f349298 feat: register chat participant and update package configuration
+437bb33d refactor: remove custom WebView HTML/CSS/JS files
+8c921925 refactor: deprecate custom WebView and update service registration
+a237dde4 feat: implement native Chat API rendering components
+361adbe9 feat: add feature flag service interface and chat integration types
+0edde636 docs: add chat-api-migration spec documents
+e77f3755 build: improve vscode compatibility detection
+2178f6bd promptSectionVisualizer: add core feature implementation
+ff65a17c ci: hydrate simulation cache from upstream
+2e2b7e5d docs: clarify simulation cache prune helper usage and add fallback tsx invocation; remove handoff.md
+279b1d36 docs: capture simulation cache maintenance plan
+dd07b90d chore: add simulation cache pruning helper
+9fed4d50 ci: prevent cache layer commits
+23adc962 build: hydrate simulation cache during postinstall
+5d7f5731 automation: harden nightly sync LFS handling (#none)
+213278dc Fix Git LFS push failures and enable manual workflow triggering from any branch (#23)
+ef689f7f Handle merge conflicts by creating PR instead of aborting (#21)
+b4ba3c4e Fix Git LFS merge errors by skipping smudge filter
+76a4ae11 Simplify GitHub CLI authentication check
+946536f1 test: support fork repo detection (#none)
+c7dbf963 automation: add nightly merge sync workflow (#none)
+63114438 automation: retire legacy sync workflows (#none)
+309f60bf automation: add fork main sync workflow
+3729eb14 Fix sync-fork-main-pr.sh: Use owner:branch format for gh pr create (#16)
+f2d2f00d Fix sync-fork-main-pr.sh to check commit count instead of content diff (#15)
+5642e60e Fix false positive error on login check in sync script (#14)
+d5710473 Remove token scopes from GitHub auth status check
+d7266119 Add environment setting to fork-main-sync workflow
+8b5ee3f2 Automation/fork main sync (#13)
+814f114b automation: add fork main sync workflow (#12)
+10503bf3 build: enforce vscode build date check (#none) (#11)
+53a926ed build: enforce vscode compat check (#none)
+f460da4d chore(gitignore): add *.vsix to ignore packaged extensions
+a1d1b5fc docs(archived): add archived design, intent, chat UI, prompt and type-hierarchy maintenance docs
+b9a8cc16 fix(type-hierarchy): align path usage across runtimes
+809ab48a docs(maintenance): clarify delegate scripts per review
+0e69473b workflow: externalize maintenance delegate logic
+fcaec219 maintenance: auto delegate failing checks
+caedc8ea maintenance: add copilot delegate workflow
+c7edc612 docs: generalize maintenance playbook
+cb91b7ae maintenance: use github runners with npm cache
+1e86d993 maintenance: bootstrap stack branch in script
+146d478e maintenance: schedule upkeep workflow
+2041a6da maintenance: add type hierarchy upkeep workflow
+788f7e73 type-hierarchy: register provider and tooling docs
+06b08aa3 feat(typeHierarchy): add TypeScript provider infrastructure
+8c1b5549 feat(tools): implement LSP type hierarchy tool with complete interface support
+c29f22ed feat(tools): implement type hierarchy LSP tool
+60567a67 docs: Add comprehensive LSP capabilities documentation and verification
+f3332f98 docs(agent-mode): align references with standards

--- a/script/sync-fork-merge.sh
+++ b/script/sync-fork-merge.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+	printf '==> %s\n' "$1"
+}
+
+require_cmd() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		printf 'Missing required command: %s\n' "$1" >&2
+		exit 1
+	fi
+}
+
+commit_without_hooks() {
+	HUSKY=0 LINT_STAGED=0 git commit "$@"
+}
+
+gh_repo_cmd() {
+	if [[ -n "$fork_repo_slug" ]]; then
+		GH_REPO="$fork_repo_slug" gh "$@"
+	else
+		gh "$@"
+	fi
+}
+
+append_env() {
+	printf '%s=%s\n' "$1" "$2" >>"$GITHUB_ENV"
+}
+
+extract_github_slug() {
+	local url="${1:-}"
+	url="${url%.git}"
+	if [[ "$url" =~ github\.com[:/]+([^/]+/[^/]+)$ ]]; then
+		echo "${BASH_REMATCH[1]}"
+	fi
+}
+
+require_cmd git
+require_cmd gh
+require_cmd git-lfs
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+	printf 'GH_TOKEN is not set; provide a token with `repo` scope.\n' >&2
+	exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [[ -z "${GITHUB_ENV:-}" ]]; then
+	export GITHUB_ENV="$repo_root/.github/tmp/github-env-$(date +%s)"
+	mkdir -p "$(dirname "$GITHUB_ENV")"
+	log "Using local GITHUB_ENV at $GITHUB_ENV"
+fi
+
+log_dir="${SYNC_LOG_DIR:-$repo_root/.github/tmp/sync-logs}"
+mkdir -p "$log_dir"
+
+sync_branch="${SYNC_BRANCH:-automation/nightly-upstream-merge}"
+sanitized_branch="${sync_branch//\//-}"
+merge_log="$log_dir/merge-${sanitized_branch}-$(date +%s).log"
+touch "$merge_log"
+append_env MERGE_LOG_PATH "$merge_log"
+append_env SYNC_LOG_DIR "$log_dir"
+exec > >(tee -a "$merge_log")
+exec 2>&1
+
+upstream_commit_log="$log_dir/upstream-commits-${sanitized_branch}-$(date +%s).log"
+: >"$upstream_commit_log"
+append_env UPSTREAM_LOG_PATH "$upstream_commit_log"
+
+target_branch="${TARGET_BRANCH:-main}"
+fork_remote="${FORK_REMOTE:-origin}"
+upstream_remote="${UPSTREAM_REMOTE:-upstream}"
+upstream_repo="${UPSTREAM_REPO:-microsoft/vscode-copilot-chat}"
+upstream_branch="${UPSTREAM_BRANCH:-main}"
+fork_repo_slug="${FORK_REPO_SLUG:-}"
+pr_title="${PR_TITLE:-Nightly upstream merge sync}"
+pr_body_header="${PR_BODY:-Automated nightly merge of upstream main into fork main.}"
+pr_reviewer="${PR_REVIEWER:-github-copilot}"
+cleanup_branch="${CLEANUP_BRANCH_ON_MERGE:-1}"
+cleanup_on_no_changes="${CLEANUP_BRANCH_ON_NO_CHANGES:-1}"
+conflict_mode="${MERGE_CONFLICT_MODE:-commit}"
+
+dry_run_flag="${DRY_RUN:-false}"
+dry_run_flag="${dry_run_flag,,}"
+
+if [[ "$conflict_mode" != "commit" && "$conflict_mode" != "report" ]]; then
+	printf 'Unsupported MERGE_CONFLICT_MODE value: %s (expected commit or report)\n' "$conflict_mode" >&2
+	exit 3
+fi
+
+check_gh_token() {
+	set +e
+	local auth_output
+	auth_output="$(gh auth status 2>&1)"
+	local status=$?
+	set -e
+	if [[ "$status" -ne 0 ]]; then
+		printf '%s\n' "$auth_output" >&2
+		printf 'GitHub CLI is not authenticated. Provide GH_TOKEN with repo scope.\n' >&2
+		exit 2
+	fi
+}
+
+check_gh_token
+
+log "Configuring Git for pointer-only sync"
+git config lfs.allowincompletepush true
+GIT_LFS_SKIP_SMUDGE=1 git lfs install --local --skip-smudge >/dev/null 2>&1 || true
+export GIT_LFS_SKIP_SMUDGE=1
+
+if [[ -z "$fork_repo_slug" ]]; then
+	fork_remote_url="$(git remote get-url "$fork_remote" 2>/dev/null || true)"
+	if [[ -n "$fork_remote_url" ]]; then
+		fork_repo_slug="$(extract_github_slug "$fork_remote_url")"
+	fi
+fi
+
+append_env SYNC_OUTCOME ""
+
+ensure_upstream_remote() {
+	local upstream_url="https://github.com/${upstream_repo}.git"
+	if git remote get-url "$upstream_remote" >/dev/null 2>&1; then
+		git remote set-url "$upstream_remote" "$upstream_url"
+	else
+		git remote add "$upstream_remote" "$upstream_url"
+	fi
+}
+
+cleanup_sim_cache_artifacts() {
+	local removed=0
+	while IFS= read -r -d '' path; do
+		log "Dropping simulation cache artifact from index: $path"
+		git rm --cached -f -- "$path" >/dev/null
+		removed=1
+	done < <(git ls-files -z -- 'test/simulation/cache/*.sqlite' 'test/simulation/cache/layers/*.sqlite')
+
+	if [[ -d test/simulation/cache/layers ]]; then
+		find test/simulation/cache/layers -type f -name '*.sqlite' -print -delete 2>/dev/null | while IFS= read -r file; do
+			log "Removed untracked simulation cache layer $file"
+		done || true
+		git clean -fd -- test/simulation/cache/layers >/dev/null 2>&1 || true
+	fi
+
+	if [[ "$removed" -eq 1 ]]; then
+		log "Simulation cache artifacts stripped from index"
+	else
+		log "No simulation cache artifacts staged"
+	fi
+}
+
+cleanup_tmp_artifacts() {
+	if git ls-files -z -- '.github/tmp' '.github/tmp/*' | grep -q .; then
+		log "Removing .github/tmp artifacts from index"
+		git rm -r --cached --force -- '.github/tmp' >/dev/null 2>&1 || true
+	fi
+}
+
+close_stale_pr() {
+	local existing_pr
+	existing_pr="$(gh_repo_cmd pr list --head "$sync_branch" --base "$target_branch" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+	if [[ -n "$existing_pr" ]]; then
+		log "Closing stale PR #$existing_pr"
+		gh_repo_cmd pr close "$existing_pr" --comment "Automation closed this PR because no changes are required." >/dev/null 2>&1 || true
+		if [[ "$cleanup_on_no_changes" == "1" ]]; then
+			log "Deleting remote branch $sync_branch"
+			git push "$fork_remote" --delete "$sync_branch" >/dev/null 2>&1 || true
+		fi
+	fi
+}
+
+ensure_upstream_remote
+
+log "Fetching $upstream_remote/$upstream_branch"
+GIT_LFS_SKIP_SMUDGE=1 git fetch "$upstream_remote" "$upstream_branch"
+
+log "Fetching $fork_remote/$target_branch"
+GIT_LFS_SKIP_SMUDGE=1 git fetch "$fork_remote" "$target_branch"
+
+log "Preparing branch $sync_branch from $fork_remote/$target_branch"
+GIT_LFS_SKIP_SMUDGE=1 git switch -C "$sync_branch" "$fork_remote/$target_branch"
+
+log "Collecting upstream commit summary"
+git log --oneline "$fork_remote/$target_branch".."$upstream_remote/$upstream_branch" >"$upstream_commit_log"
+
+if [[ ! -s "$upstream_commit_log" ]]; then
+	log "No new upstream commits to merge"
+	close_stale_pr
+	append_env SYNC_OUTCOME no_changes
+	if [[ "$dry_run_flag" != "true" ]]; then
+		git push "$fork_remote" --delete "$sync_branch" >/dev/null 2>&1 || true
+	fi
+	exit 0
+fi
+
+log "Merging $upstream_remote/$upstream_branch into $sync_branch (mode: $conflict_mode)"
+set +e
+GIT_MERGE_AUTOEDIT=no git merge --no-ff --no-commit "$upstream_remote/$upstream_branch"
+merge_status=$?
+set -e
+
+collect_conflicted_files() {
+	git diff --name-only --diff-filter=U | sed 's/^/- /'
+}
+
+write_conflict_report() {
+	local files="$1"
+	local report_path="$log_dir/conflict-report-${sanitized_branch}-$(date +%s).md"
+	{
+		echo "# Merge conflict report"
+		echo ""
+		echo "* Upstream: ${upstream_remote}/${upstream_branch} ($(git rev-parse --short "$upstream_remote/$upstream_branch"))"
+		echo "* Target: ${fork_remote}/${target_branch} ($(git rev-parse --short "$fork_remote/$target_branch"))"
+		echo "* Strategy: ${conflict_mode}"
+		echo ""
+		echo "## Conflicted files"
+		if [[ -n "$files" ]]; then
+			echo "$files"
+		else
+			echo "(none detected)"
+		fi
+		echo ""
+		echo "## Next steps"
+		echo "1. Fetch \"${sync_branch}\""
+		echo "2. Re-run the merge locally"
+		echo "3. Resolve the conflicts and push updates"
+	} >"$report_path"
+	append_env CONFLICT_REPORT_PATH "$report_path"
+	log "Wrote conflict report to $report_path"
+}
+
+handle_conflicts_commit() {
+	local files
+	files="$(collect_conflicted_files || true)"
+	write_conflict_report "$files"
+	log "Conflicts detected; staging current merge state"
+	git status --short || true
+	git add -A
+	cleanup_sim_cache_artifacts
+	cleanup_tmp_artifacts
+	log "Creating conflicted merge commit"
+	commit_without_hooks --allow-empty --no-edit
+	append_env SYNC_OUTCOME merge_conflict_committed
+}
+
+handle_conflicts_report() {
+	local files
+	files="$(collect_conflicted_files || true)"
+	write_conflict_report "$files"
+	log "Conflicts detected; aborting merge (report mode)"
+	git merge --abort
+	append_env SYNC_OUTCOME merge_conflict_reported
+}
+
+if [[ "$merge_status" -ne 0 ]]; then
+	if [[ "$conflict_mode" == "commit" ]]; then
+		handle_conflicts_commit
+	else
+		handle_conflicts_report
+		if [[ "$dry_run_flag" != "true" ]]; then
+			git push "$fork_remote" --delete "$sync_branch" >/dev/null 2>&1 || true
+		fi
+		exit 0
+	fi
+else
+	cleanup_sim_cache_artifacts
+	cleanup_tmp_artifacts
+	log "Creating merge commit"
+	commit_without_hooks --allow-empty --no-edit
+	append_env SYNC_OUTCOME merge_completed
+fi
+
+log "Merge commit created: $(git rev-parse --short HEAD)"
+
+prepare_pr_body() {
+	local body="$pr_body_header"
+	local upstream_context
+	upstream_context="$(sed 's/^/- /' "$upstream_commit_log")"
+	if [[ -n "$upstream_context" ]]; then
+		body="$body"$'\n\n''Upstream commits:'$'\n'"$upstream_context"
+	fi
+	if [[ -n "${CONFLICT_REPORT_PATH:-}" && -f "${CONFLICT_REPORT_PATH:-}" ]]; then
+		body="$body"$'\n\n''Conflict report excerpt:'$'\n'"$(sed 's/^/    /' "$CONFLICT_REPORT_PATH")"
+	fi
+	echo "$body"
+}
+
+push_and_update_pr() {
+	if [[ "$dry_run_flag" == "true" ]]; then
+		log "Dry run mode enabled; skipping push and PR updates"
+		return
+	fi
+
+	log "Pushing $sync_branch to $fork_remote"
+	git push "$fork_remote" "$sync_branch" --force-with-lease
+
+	local existing_pr
+	existing_pr="$(gh_repo_cmd pr list --head "$sync_branch" --base "$target_branch" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+	local pr_body
+	pr_body="$(prepare_pr_body)"
+	local outcome_label="${SYNC_OUTCOME:-merge_completed}"
+
+	if [[ -n "$existing_pr" ]]; then
+		log "Updating existing PR #$existing_pr"
+		gh_repo_cmd pr edit "$existing_pr" --title "$pr_title" --body "$pr_body" >/dev/null
+		if [[ "$outcome_label" != "merge_conflict_committed" ]]; then
+			outcome_label=pr_updated
+		fi
+	else
+		log "Creating PR from $sync_branch to $target_branch"
+		gh_repo_cmd pr create --base "$target_branch" --head "$sync_branch" --title "$pr_title" --body "$pr_body" >/dev/null
+		existing_pr="$(gh_repo_cmd pr view "$sync_branch" --json number --jq '.number' 2>/dev/null || true)"
+		if [[ "$outcome_label" != "merge_conflict_committed" ]]; then
+			outcome_label=pr_created
+		fi
+	fi
+
+	if [[ -n "$existing_pr" ]]; then
+		append_env PR_NUMBER "$existing_pr"
+		local pr_url
+		pr_url="$(gh_repo_cmd pr view "$existing_pr" --json url --jq '.url' 2>/dev/null || true)"
+		if [[ -n "$pr_url" ]]; then
+			append_env PR_URL "$pr_url"
+		fi
+		if [[ -n "$pr_reviewer" ]]; then
+			log "Requesting review from $pr_reviewer"
+			gh_repo_cmd pr review-request "$existing_pr" --add "$pr_reviewer" >/dev/null 2>&1 || true
+		fi
+		if [[ "$cleanup_branch" == "1" ]]; then
+			local merged
+			merged="$(gh_repo_cmd pr view "$existing_pr" --json merged --jq '.merged' 2>/dev/null || echo false)"
+			if [[ "$merged" == "true" ]]; then
+				log "PR #$existing_pr already merged; deleting remote branch $sync_branch"
+				git push "$fork_remote" --delete "$sync_branch" >/dev/null 2>&1 || true
+			fi
+		fi
+	fi
+
+	append_env SYNC_OUTCOME "$outcome_label"
+}
+
+push_and_update_pr
+
+current_outcome="$(grep -E '^SYNC_OUTCOME=' "$GITHUB_ENV" | tail -n1 | cut -d'=' -f2)"
+log "Sync completed with outcome ${current_outcome:-unknown}"


### PR DESCRIPTION
## Summary
- add the merge-based nightly sync workflow that uses the new helper script so the fork tracks upstream nightly
- include the helper shell script invoked by the workflow

## Testing
- not run yet (workflow change only)