### PR TITLE
ci: trust yulongbai-nov and bot for cache guard

### DIFF
--- a/build/pr-check-cache-files.ts
+++ b/build/pr-check-cache-files.ts
@@ -38,7 +38,7 @@ const collaborators = [
 	"hawkticehurst", "hediet", "isidorn", "jo-oikawa", "joaomoreno", "joshspicer", "jrieken", "jruales", "justschen", "karthiknadig",
 	"kieferrm", "kkbrooks", "kycutler", "lramos15", "lszomoru", "luabud", "meganrogge", "minsa110", "mjbvz", "mrleemurray", "nguyenchristy",
 	"ntrogh", "olguzzar", "osortega", "pierceboggan", "pwang347", "rebornix", "roblourens", "rzhao271", "sandy081", "sbatten", "TylerLeonhardt",
-	"Tyriar", "ulugbekna", "vijayupadya", "Yoyokrazy", "yulongbai-nov"
+	"Tyriar", "ulugbekna", "vijayupadya", "Yoyokrazy", "yulongbai-nov", "github-actions[bot]"
 ];
 const collaboratorSet = new Set(collaborators);
 const verificationOverrides = new Set(["github-actions[bot]", "yulongbai-nov"]);


### PR DESCRIPTION
## Summary
- allow  and  to update simulation cache files (used by nightly automation) while still enforcing collaborator + verification checks for everyone else
- add a verification override list so trusted accounts can skip the GPG requirement while keeping collaborator-only enforcement for cache layers

## Testing
- lint-staged (auto via commit)