### PR TITLE
Add workbench prompt inspector spec

### DIFF
--- a/.kiro/specs/prompt-inspector-workbench/design.md
+++ b/.kiro/specs/prompt-inspector-workbench/design.md
@@ -1,0 +1,133 @@
+# Design Document: Workbench Prompt Inspector
+
+## Overview
+
+We are upgrading the Live Request Editor/Prompt Inspector from a standalone webview to a first-class **workbench-native surface**. The new experience must sit alongside the existing Copilot Chat UI (panel, side panel, detached window), reuse as much of the chat renderer as possible, and expose richer tooling for power users who craft or intercept prompts. Key goals:
+
+- Share the same look, feel, and accessibility semantics as Copilot Chat by running inside the VS Code workbench instead of a sandboxed React webview.
+- Support multi-window/multi-surface layouts (panel, editor area, pop-out window) exactly like the chat panel, including drag-and-drop docking.
+- Provide deeper inspection of **sub-agent** requests (nested intercepts), presenting them recursively and allowing targeted edits before they are sent downstream.
+- Preserve and extend the current editing semantics (dirty state, reset, per-section editing/deletion) while opening the door to future context engineering features (memory blocks, custom summaries, MCP hosting).
+
+Non-goals for this increment:
+
+- Shipping a brand-new renderer independent of Copilot Chat. We deliberately aim to reuse the chat renderer and styles wherever practical.
+- Implementing autonomous MCP tooling. We will ensure the architecture allows future agent integrations, but we only need hooks/abstractions for now.
+
+## Current Architecture
+
+| Layer | Responsibility | Limitations |
+| --- | --- | --- |
+| `LiveRequestEditorService` (extension host) | Tracks editable requests, dirty state, reset, interception, token counts. | Already workbench-safe. No change needed. |
+| `LiveRequestEditorProvider` + `main.tsx` webview | React bundle rendering sections via Markdown-It, receiving updates via `postMessage`. | Cannot reuse chat renderer; limited theming/accessibility parity; no native docking. |
+| Prompt pipeline (`defaultIntentRequestHandler`, `ChatMLFetcher`) | Builds editable requests, applies edits, enforces validation. | Already integrated; stays the same. |
+
+## Proposed Architecture
+
+### High-level structure
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ VS Code Workbench                                        │
+│  ┌──────────────────────────────┐  ┌───────────────────┐ │
+│  │ Copilot Chat Panel           │  │ Prompt Inspector │ │
+│  │ (existing chat renderer)     │  │ (new workbench   │ │
+│  │                              │  │  contribution)   │ │
+│  └──────────────────────────────┘  └───────────────────┘ │
+│           │                                ▲            │
+│           ▼                                │            │
+│  Chat renderer components & styles  ───────┘ shared     │
+│           │                                           │
+│           ▼                                           │
+│  LiveRequestInspectorView (TS/TSX in workbench)        │
+│           │                                           │
+│           ▼                                           │
+│  LiveRequestInspectorController (extension host)      │
+│           │                                           │
+│           ▼                                           │
+│  ILiveRequestEditorService / interception plumbing     │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Workbench contribution
+
+- Register a new **view container** (e.g., `copilot.promptInspector`) that behaves like the existing chat container. It can appear in the panel, sidebar, or as a detached window via VS Code’s built-in “drag tab” support.
+- Inside the container, render a **custom webview-less view** using the same infrastructure as the chat panel (the “chat surface”). That gives us virtualization, markdown rendering, hover toolbars, keyboard navigation, etc.
+- The view controller (`LiveRequestInspectorView`) subscribes to `ILiveRequestEditorService.onDidChange` events, just like the webview does today, but it renders directly via TS/JS on the workbench side rather than going through `postMessage`.
+
+### Sub-agent recursion
+
+- Extend the service to emit a tree of “request nodes” when sub-agents spawn nested requests. Each node captures: session key, agent id, parent request id, interception state.
+- The UI renders this as a collapsible tree (similar to a chat thread list). Selecting a sub-node reuses the same section renderer but scrolled into a nested panel that can slide in from the side (using VS Code’s split view control or a custom details pane).
+- Interception banners and action buttons propagate down the tree. Blocking/Resume/Cancel operate on whichever node is active.
+- Configuration options (depth limit, filters) live in the inspector settings and feed into the service so we do not subscribe to unnecessary events.
+
+### Layout and styling
+
+- Base the inspector layout on the chat panel’s components. The section renderer becomes a specialized variant of the chat message renderer, with collapsible metadata and the existing hover toolbar reused.
+- Sticky metadata header (model, token budget, dirty state, reset) uses VS Code’s `WorkbenchToolBar` and `Breadcrumbs` components to ensure focus/ARIA parity.
+- Slide-in details: reuse VS Code’s split-view API (`SplitView`, `PaneComposite`) to animate sub-agent panes from the right. Nested sub-agents can push additional panes, breadcrumbing back to the parent request.
+
+### Extensibility hooks
+
+- Since we are now native, we can expose commands (e.g., `promptInspector.insertMemoryBlock`) that future MCP agents/tools can invoke. For now, define a lightweight interface on the view controller to register “prompt augmentation providers”; they surface under a new “Add context/memory” button.
+- Ensure the inspector view can be instantiated per window (one per VS Code window like the chat panel). The service already keys requests per `(sessionId, location)`.
+
+### Telemetry & diagnostics
+
+- Reuse existing `liveRequestEditor.*` telemetry, but tag events with `surface: workbench-native` so we can monitor rollout.
+- Add counters for sub-agent depth usage, interception outcomes per depth, and custom augmentation usage (future memory blocks).
+
+## Components
+
+| Component | Description |
+| --- | --- |
+| `LiveRequestInspectorView` (new) | Workbench UI view that renders sections using chat renderer components, handles selection, dirty state badges, slide-in sub-agent panes, and user commands. |
+| `LiveRequestInspectorController` (new) | Glue between the view and `ILiveRequestEditorService`. Maintains the request tree, applies filters/depth, surfaces commands. |
+| `ILiveRequestEditorService` (existing) | Enhanced to track request hierarchy metadata and configurable observer depth. |
+| `LiveRequestInspectorPanel` (new contribution) | VS Code view container definition + commands for opening, toggling, detach/attach. |
+
+## Data & Control Flow
+
+1. Copilot Chat’s intent handler builds an editable request via `ILiveRequestEditorService.prepareRequest` (unchanged).
+2. The service records additional metadata when a sub-agent spawns a new request (parent id, agent name, depth).
+3. `LiveRequestInspectorController` subscribes to service events, materialises a tree, and pushes updates to the view.
+4. The view renders the root request sections, plus a sidebar/tree for sub-agents. Selecting a node loads its sections in the main canvas, optionally sliding previous context aside.
+5. Edits/deletes/reset actions invoke the same service methods as before. Because we share the chat renderer, inline editing uses the same components as chat bubbles (e.g., `ChatEditableBlock`).
+6. Interception events surface via the existing banner but now piggyback on workbench notifications rather than webview postMessage.
+
+## Integration Points
+
+- **Copilot Chat renderer**: reuse message/markdown components, hover toolbar styles, token meter.
+- **VS Code view/panel system**: register `Prompt Inspector` so it docks like chat.
+- **Interception commands**: reuse `github.copilot.liveRequestEditor.toggleInterception` etc.
+- **Settings**: add `github.copilot.chat.promptInspector.depthLimit`, `…filterAgents`, etc. so users can scope sub-agent monitoring.
+
+## Migration / Rollout Strategy
+
+1. Introduce the workbench-native view under a new setting/flag (`…promptInspectorWorkbenchEnabled`). Keep the webview available as fallback.
+2. Mirror functionality (editing, reset, interception) inside the workbench view; run both surfaces side-by-side for insiders.
+3. Once parity is confirmed, flip the default to workbench view and eventually retire the webview bundle.
+
+## Performance / Reliability / Security / UX
+
+- **Performance**: Chat renderer already handles large prompts; ensure we virtualize section lists just like chat transcripts. Lazy-load nested sub-agent views to avoid rendering everything upfront.
+- **Reliability**: Centralizing in the workbench reduces message-passing errors. Add error banners if the service cannot supply a request tree.
+- **Security**: No custom HTML injection from React; we rely on VS Code’s trusted renderer, reducing CSP maintenance.
+- **UX**: Focus management reuses VS Code’s tabbing model. Slide-in panes should be keyboard-accessible (use `SplitView` focus APIs). Interception banners need ARIA live regions as before.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Chat renderer is not fully reusable | Audit component dependencies; wrap missing pieces (e.g., ChatSection) in a shared package `@copilot/chat-renderer`. |
+| Regresions in existing webview | Keep both surfaces behind flags until parity is validated; add telemetry comparisons.
+| Sub-agent tree complexity overwhelms UI | Add configurable depth/filter + collapsed nodes by default; render counts rather than full lists for deep trees.
+| Future MCP/tooling integration unknown | Define provider API but keep implementation minimal; ensure the view controller exposes stable commands/hooks.
+
+## Future Enhancements
+
+- Visual diffing between original and edited prompt sections using the native diff renderer.
+- “Prompt augmentation providers” that can insert memory/context snippets, optionally powered by MCP servers.
+- Export/import editable requests directly from the inspector.
+- Allow other agents/tools to open the inspector via API to programmatically inspect or modify prompts.

--- a/.kiro/specs/prompt-inspector-workbench/requirements.md
+++ b/.kiro/specs/prompt-inspector-workbench/requirements.md
@@ -1,0 +1,93 @@
+# Requirements Document
+
+## Introduction
+
+We are building a **Workbench Prompt Inspector** that brings the Live Request Editor directly into the VS Code workbench. Power users should be able to inspect, edit, and intercept prompt sections using the same renderer and layout options as Copilot Chat (panel, side panel, popped-out window). The inspector must support recursive sub-agent monitoring: when secondary agents produce their own requests, the inspector reveals them as nested panes so the user can intercept or modify each stage. Alongside parity with today’s webview, the new surface should unlock advanced context-engineering workflows (memory injection, custom summaries) and eventually expose hooks for external agents/tools.
+
+**Goals**
+
+- Deliver a workbench-native inspector that reuses Copilot Chat’s renderer, theming, accessibility, and docking behaviors.
+- Maintain full editing/interception feature set (dirty state, reset, delete/restore, send blocking) and extend it to sub-agent requests.
+- Allow configurable monitoring depth/filters and prepare the surface for future prompt augmentation providers (memory blocks, MCP integration).
+
+**Non-goals**
+
+- Shipping a refactored prompt pipeline; we continue using `ILiveRequestEditorService`.
+- Implementing full MCP tooling inside the inspector in this iteration (we only add hooks).
+
+## Glossary
+
+- **Workbench Prompt Inspector** – New workbench-native view that displays editable prompt sections.
+- **Sub-agent** – Any secondary agent/tool that initiates a nested request during the main conversation (e.g., summarizer, planner).
+- **Interception** – Flow where prompt sends pause until user resumes/cancels.
+- **Request Node** – A specific editable request (root or sub-agent) tracked by `ILiveRequestEditorService`.
+- **Depth Limit** – User-configurable maximum nesting level to monitor.
+- **Prompt Augmentation Provider** – Future plug-in (possibly MCP) that can insert additional context/memory into the editable request.
+
+## Requirements
+
+### Requirement 1 – Workbench-native Surface
+
+**User Story**: As a Copilot power user, I want the Prompt Inspector to behave like other VS Code views so I can dock, drag, or pop it out just like Copilot Chat.
+
+#### Acceptance Criteria
+
+1.1 THE Prompt Inspector SHALL register as a VS Code view/panel that can appear in the panel, side bar, or detached window.
+1.2 WHEN the user drags the Prompt Inspector tab, THEN VS Code SHALL allow docking anywhere the chat panel can dock.
+1.3 WHEN multiple VS Code windows are open, THEN each window SHALL host its own inspector instance scoped to conversations in that window.
+1.4 THE Prompt Inspector view SHALL use VS Code’s theme tokens and accessibility patterns (focus rings, ARIA labels) identical to Copilot Chat.
+
+### Requirement 2 – Renderer Parity
+
+**User Story**: As someone inspecting prompts, I want sections to look and behave like chat messages so I immediately understand the content and actions.
+
+#### Acceptance Criteria
+
+2.1 THE inspector SHALL reuse Copilot Chat’s message renderer for section headers/body/markdown instead of Markdown-It.
+2.2 THE inspector SHALL display section hover toolbars (Edit/Delete/Restore) styled identically to the chat code-block toolbar.
+2.3 THE inspector SHALL support inline editing using the same components/chat theme as chat bubbles.
+2.4 WHEN token counts are available, THEN the inspector SHALL show token meters using the existing chat token meter component.
+2.5 WHEN sections are dirty/deleted, THEN the inspector SHALL show badges/styles consistent with the existing webview behaviors.
+
+### Requirement 3 – Sub-agent Monitoring
+
+**User Story**: As a developer tracing multi-agent workflows, I want to see nested requests and drill into each one before it sends.
+
+#### Acceptance Criteria
+
+3.1 THE inspector SHALL render a tree/list of request nodes (root + sub-agents) with parent/child relationships.
+3.2 WHEN the user selects a sub-agent node, THEN its prompt sections SHALL animate into view (e.g., slide-in pane) while preserving access to the parent node.
+3.3 THE inspector SHALL support recursive navigation (depth ≥ 3) without reloading the entire view.
+3.4 THE user SHALL be able to configure monitoring depth and agent filters via settings; filtered nodes SHALL be hidden but counted.
+3.5 WHEN a sub-agent request triggers interception, THEN the inspector SHALL show the same interception banner/buttons scoped to that node.
+
+### Requirement 4 – Editing & Interception Parity
+
+**User Story**: As a Prompt Inspector user, I need the same editing and interception controls that currently exist in the webview so I can safely modify prompts.
+
+#### Acceptance Criteria
+
+4.1 THE inspector SHALL surface dirty state badges and Reset actions identical to the current experience.
+4.2 WHEN validation fails (e.g., empty prompt), THEN the inspector SHALL block send, show the banner, and disable Resume actions until resolved.
+4.3 All edit/delete/restore/reset actions SHALL call the existing service APIs and update the view immediately.
+4.4 Interception mode (resume/cancel) SHALL be fully supported in the workbench view, including auto-focus when a request pauses.
+
+### Requirement 5 – Configurability & Future Hooks
+
+**User Story**: As an advanced user, I want to customize how much data the inspector shows and prepare for future context injections.
+
+#### Acceptance Criteria
+
+5.1 THE inspector SHALL expose settings for sub-agent depth limit, agent filters, and telemetry opt-in for detailed logging.
+5.2 THE inspector SHALL provide commands/extension points for “prompt augmentation providers” (e.g., insert memory block). For this iteration, the hooks MAY be no-ops but MUST be wired into the view/controller.
+5.3 WHEN augmentation providers inject content, THEN the inspector SHALL mark sections as augmented and update dirty state accordingly.
+
+### Requirement 6 – Compatibility & Rollout
+
+**User Story**: As a Copilot maintainer, I need a safe migration path from the webview to the workbench surface.
+
+#### Acceptance Criteria
+
+6.1 THE feature SHALL be gated behind a new configuration flag so insiders can opt in without removing the webview.
+6.2 WHEN the flag is disabled, THEN the existing webview implementation SHALL remain unaffected.
+6.3 Telemetry SHALL differentiate between webview and workbench usage to monitor adoption and regressions.

--- a/.kiro/specs/prompt-inspector-workbench/tasks.md
+++ b/.kiro/specs/prompt-inspector-workbench/tasks.md
@@ -1,0 +1,59 @@
+# Implementation Plan
+
+## Status Snapshot
+
+- 📋 Design + requirements drafted; workbench-native inspector scoped.
+- ⚙️ Core services (`ILiveRequestEditorService`, interception plumbing) already exist and remain reusable.
+- 🧭 Next up: build the workbench view, reuse chat renderer components, and wire in sub-agent tree + settings.
+
+## Checklist
+
+- [ ] 1. Workbench infrastructure
+  - [ ] 1.1 Add feature flag `github.copilot.chat.promptInspectorWorkbenchEnabled`; default false.
+  - [ ] 1.2 Register new view container/panel contribution `copilot.promptInspectorWorkbench` with commands (`show`, `toggle`).
+  - [ ] 1.3 Implement `LiveRequestInspectorPanel` host that instantiates the view/controller when the flag is on.
+
+- [ ] 2. Shared renderer extraction
+  - [ ] 2.1 Identify chat renderer components needed for sections (message bubble, hover toolbar, token meter) and extract them into a shared module (or re-export existing ones) consumable by the inspector.
+  - [ ] 2.2 Provide a lightweight adapter so inspector sections can reuse the markdown/chat block renderer without workbench-only dependencies.
+
+- [ ] 3. View/controller implementation
+  - [ ] 3.1 Build `LiveRequestInspectorController` that subscribes to `ILiveRequestEditorService`, tracks request tree, enforces depth/filter settings.
+  - [ ] 3.2 Implement `LiveRequestInspectorView` using VS Code’s chat surface primitives: render section list, metadata header, action buttons.
+  - [ ] 3.3 Port existing actions (edit, delete, restore, reset) to invoke service APIs; ensure dirty state + validation banners mirror webview.
+  - [ ] 3.4 Integrate interception banners/buttons and auto-focus logic.
+
+- [ ] 4. Sub-agent experience
+  - [ ] 4.1 Extend service events (or add helper) to expose parent/child metadata for request nodes.
+  - [ ] 4.2 Render request tree navigation (sidebar or breadcrumbs) with slide-in panes for nested selections.
+  - [ ] 4.3 Implement settings for depth/filter and honor them when building the view.
+  - [ ] 4.4 Ensure nested interception banners/actions apply to the active node.
+
+- [ ] 5. Settings & extensibility hooks
+  - [ ] 5.1 Add configuration keys for depth limit, agent filter, telemetry opt-in.
+  - [ ] 5.2 Define command/registry for “prompt augmentation providers”; for now provide a stub hook/injection point.
+  - [ ] 5.3 Surface a placeholder UI affordance (e.g., “Add Memory/Context”) that calls the provider hook.
+
+- [ ] 6. Rollout & parity
+  - [ ] 6.1 Add telemetry distinguishing webview vs. workbench inspector usage.
+  - [ ] 6.2 Create experimental command to switch between surfaces at runtime for testing.
+  - [ ] 6.3 Update docs + manual test plan covering workbench layout, sub-agent recursion, editing, interception.
+
+## Implementation Notes
+
+- Reuse VS Code’s `SplitView`/`PaneComposite` to animate slide-in panes for sub-agents; ensure tab/focus order stays logical.
+- Consider using the existing Chat panel data model (same `IChatModel`) for rendering convenience; map inspector sections to pseudo-chat messages.
+- Keep the old webview code path for fallback until telemetry shows confidence.
+
+## Dependencies
+
+- Copilot chat renderer components (and any internal APIs they require).
+- VS Code workbench APIs for custom views/panels.
+- Existing `ILiveRequestEditorService` events and interception commands.
+
+## Testing Priority
+
+- High: editing + interception parity (dirty state, validation banner, resume/cancel) inside the workbench view.
+- High: sub-agent navigation correctness, including depth filtering and slide-in UI.
+- Medium: multi-window behavior and docking/detach scenarios.
+- Medium: settings toggles + telemetry coverage.


### PR DESCRIPTION
## Summary\n- add design/requirements/tasks for workbench-native prompt inspector\n- outline plan for sub-agent monitoring and chat renderer reuse\n\n## Testing\n- not applicable (spec only)\n