### PR TITLE
Add workflow to publish VSIX via GitHub release

### DIFF
--- a/.github/workflows/publish-vsix.yml
+++ b/.github/workflows/publish-vsix.yml
@@ -1,0 +1,61 @@
+name: Build VSIX and attach to release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (defaults to current ref if it is a tag)'
+        required: false
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    name: Build VSIX
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          lfs: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.14.x'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build VSIX
+        run: npm run package
+
+      - name: Locate VSIX
+        id: vsix
+        run: |
+          set -e
+          file="$(ls -1 *.vsix | head -n 1)"
+          echo "file=$file" >>"$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix
+          path: ${{ steps.vsix.outputs.file }}
+
+      - name: Create or update release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.vsix.outputs.file }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          name: ${{ inputs.tag || github.ref_name }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the VSIX on tag pushes or manual dispatch
- upload the VSIX both as a workflow artifact and as an asset on the tagged release
- use Node 22 and npm cache for packaging

## Testing
- not run (workflow change only)