### PR TITLE
feature/chat timeline replay

### DIFF
--- a/src/extension/prompt/node/liveRequestEditorService.ts
+++ b/src/extension/prompt/node/liveRequestEditorService.ts
@@ -1158,7 +1158,7 @@ export class LiveRequestEditorService extends Disposable implements ILiveRequest
 		for (const section of request.sections.slice(0, limit)) {
 			const original = section.originalContent ?? '';
 			const current = section.deleted ? '' : (section.content ?? '');
-			const deleted = !!section.deleted && !!original.length;
+			const deleted = !!section.deleted;
 			if (!deleted && original === current) {
 				continue;
 			}


### PR DESCRIPTION
- **Tests: cover section edit/delete/reset flows**
- **Tests: fix live request editor spec typing**
- **Simulation: add live request editor send coverage**
- **Specs: add replay/persistence requirements and update tasks**
- **Tests: ensure edited prompts reach fetcher when interception is off**
- **Auto override: persist deletions and ensure fetcher uses edited messages**
