### PR TITLE
Strip sampling controls for gpt-5.1 family

### DIFF
--- a/docs/live-request-editor-user-guide.md
+++ b/docs/live-request-editor-user-guide.md
@@ -41,7 +41,11 @@ Raw Request Payload
 - Idle state: “Live Request Editor idle — send a chat request to populate metadata.”
 - When `sessionMetadata.fields` is empty, the metadata section hides but the token node/placeholder remains.
 - Outline nodes truncate after a safety budget and surface “... entries truncated ...” markers.
-- Reasoning-only models that reject sampling controls (e.g., `o1`, `o1-mini`) have `temperature` / `top_p` / `n` stripped before send, so the Request Options node omits them.
+<<<<<<< HEAD
+- Models that reject sampling controls (e.g., `o1`, `o1-mini`, any `gpt-5.1*` including codex / codex-max / mini) have `temperature` / `top_p` / `n` stripped before send, so the Request Options node omits them.
+=======
+- Models that reject sampling controls (e.g., `o1`, `o1-mini`, any `gpt-5.1*` including codex / codex-max / mini) have `temperature` / `top_p` / `n` stripped before send, so the Request Options node omits them.
+>>>>>>> 2f92728c (Strip sampling for all gpt-5.1 variants and document)
 
 ## Modes
 - **Send normally**: Sends immediately; editor is view-only.

--- a/docs/liveRequestEditor.md
+++ b/docs/liveRequestEditor.md
@@ -72,7 +72,11 @@ The request that is ultimately sent to the LLM is built in several steps:
        - `temperature`, `top_p`, `n`
        - `tools`, `tool_choice`
        - `prediction`, `reasoning`, `intent`, `state`, `snippy`, etc.
-     - For reasoning-focused models that reject sampling controls (e.g., `o1`, `o1-mini`), the request builder strips `temperature`, `top_p`, and `n` to avoid `invalid_request_body` errors. The metadata view will omit those keys for such models.
+<<<<<<< HEAD
+     - For models that reject sampling controls (e.g., `o1`/`o1-mini`, the entire `gpt-5.1*` family including codex/codex-max/mini), the request builder strips `temperature`, `top_p`, and `n` to avoid `invalid_request_body` errors. The metadata view will omit those keys for such models.
+=======
+     - For models that reject sampling controls (e.g., `o1`/`o1-mini`, the entire `gpt-5.1*` family including codex/codex-max/mini), the request builder strips `temperature`, `top_p`, and `n` to avoid `invalid_request_body` errors. The metadata view will omit those keys for such models.
+>>>>>>> 2f92728c (Strip sampling for all gpt-5.1 variants and document)
 
 4. **Network layer**
    - `networkRequest` / `postRequest` attach headers and send `IEndpointBody` as `request.json`.

--- a/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
+++ b/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
@@ -315,7 +315,7 @@ suite('defaultIntentRequestHandler', () => {
 		clearSubagentHistory(): void {
 			// no-op
 		}
-	getMetadataSnapshot(): LiveRequestMetadataSnapshot | undefined {
+		getMetadataSnapshot(): LiveRequestMetadataSnapshot | undefined {
 			return undefined;
 		}
 	}

--- a/src/platform/endpoint/node/chatEndpoint.ts
+++ b/src/platform/endpoint/node/chatEndpoint.ts
@@ -43,7 +43,10 @@ export function stripSamplingParameters(body: IEndpointBody | undefined, family:
 	}
 
 	const normalizedFamily = family.toLowerCase();
-	const disallowSamplingControls = normalizedFamily.startsWith('o1') || modelId === CHAT_MODEL.O1 || modelId === CHAT_MODEL.O1MINI;
+	const disallowSamplingControls = normalizedFamily.startsWith('o1')
+		|| normalizedFamily.startsWith('gpt-5.1')
+		|| modelId === CHAT_MODEL.O1
+		|| modelId === CHAT_MODEL.O1MINI;
 	if (!disallowSamplingControls) {
 		return;
 	}

--- a/src/platform/endpoint/test/node/chatEndpoint.spec.ts
+++ b/src/platform/endpoint/test/node/chatEndpoint.spec.ts
@@ -39,4 +39,42 @@ describe('stripSamplingParameters', () => {
 		expect(body.top_p).toBeUndefined();
 		expect(body.n).toBeUndefined();
 	});
+
+	it('keeps sampling parameters for gpt-5 family', () => {
+		const body: IEndpointBody = { temperature: 0.6, top_p: 0.7, n: 1, model: 'gpt-5' };
+
+		stripSamplingParameters(body, 'gpt-5');
+
+		expect(body.temperature).toBe(0.6);
+		expect(body.top_p).toBe(0.7);
+		expect(body.n).toBe(1);
+	});
+
+	it('removes sampling parameters for all gpt-5.1 family variants', () => {
+		const families = [
+			'gpt-5.1',
+			'gpt-5.1-mini',
+			'gpt-5.1-codex',
+			'gpt-5.1-codex-mini',
+			'gpt-5.1-codex-max'
+		];
+
+		for (const family of families) {
+			const body: IEndpointBody = { temperature: 0.3, top_p: 0.95, n: 3, model: family };
+			stripSamplingParameters(body, family);
+			expect(body.temperature, `${family} temperature`).toBeUndefined();
+			expect(body.top_p, `${family} top_p`).toBeUndefined();
+			expect(body.n, `${family} n`).toBeUndefined();
+		}
+	});
+
+	it('keeps sampling parameters for gpt-5-codex (non-5.1)', () => {
+		const body: IEndpointBody = { temperature: 0.25, top_p: 0.85, n: 2, model: 'gpt-5-codex' };
+
+		stripSamplingParameters(body, 'gpt-5-codex');
+
+		expect(body.temperature).toBe(0.25);
+		expect(body.top_p).toBe(0.85);
+		expect(body.n).toBe(2);
+	});
 });


### PR DESCRIPTION
## Summary
- strip temperature/top_p/n from requests for all gpt-5.1* variants (including codex/codex-max/mini) in addition to o1 family
- expand stripSamplingParameters tests to cover gpt-5.1 variants and ensure gpt-5/gpt-5-codex still keep sampling controls
- update docs to note gpt-5.1* models omit sampling fields in metadata

## Testing
- npx vitest run src/platform/endpoint/test/node/chatEndpoint.spec.ts