### PR TITLE
Feature/spec refactor

### DIFF
--- a/.kiro/specs/chat-timeline-replay/design.md
+++ b/.kiro/specs/chat-timeline-replay/design.md
@@ -82,10 +82,20 @@ When a user edits or deletes sections in the Live Request Editor and sends, offe
 Live Request Editor (edits/undo/redo)
         |
         v
- Replay Builder (projection, trimmed payload)
+Replay Builder (projection, trimmed payload)
         |
         v
- Replayed Session (chat view)
+Replayed Session (chat view)
    - Display-only by default
    - “Start chatting from this replay” => enable input (fork)
 ```
+
+## Sync & Parity Notes
+- Single source of truth: Live Request Editor service state (trimmed messages + metadata). Replay builds from that state; no divergent copies.
+- Version/hash: Each replay build should carry `version`/`lastUpdated` and a payload hash; UIs ignore stale updates.
+- Parent linkage: Stamp replay sessions with `replay_parent_session_id` and `replay_parent_turn_id` for unambiguous lookup.
+- Payload parity: Replay uses the exact trimmed payload sent/queued; projection is display-only. If edits/undo change the payload, bump version and invalidate/rebuild replay.
+- Event scoping: Emit changes keyed by session; views render only when targeting that session to avoid bleed.
+- Stale handling: If the request is cleared/canceled/context-switched, mark replay as stale/cleared rather than freezing old data.
+- Debounce/merge: Debounce rapid edits before emitting to replay to reduce flicker; coalesce updates.
+- Parity warning: If logged request hash ≠ replay hash, surface a warning chip/banner in replay and metadata views.

--- a/.kiro/specs/chat-timeline-replay/design.md
+++ b/.kiro/specs/chat-timeline-replay/design.md
@@ -99,3 +99,12 @@ Replayed Session (chat view)
 - Stale handling: If the request is cleared/canceled/context-switched, mark replay as stale/cleared rather than freezing old data.
 - Debounce/merge: Debounce rapid edits before emitting to replay to reduce flicker; coalesce updates.
 - Parity warning: If logged request hash ≠ replay hash, surface a warning chip/banner in replay and metadata views.
+
+## Global Mode Interactions (Interception/Override/Replay)
+- Defaults: Interception OFF, Auto-apply OFF, Replay manual (flag off by default). Replay is additive and does not replace interception/override.
+- Independence: Replay does not pause sends; interception is the only pause mechanism. Auto-apply persists prefix edits; replay does not.
+- UI simplicity: In the replay view, keep interception/override OFF by default. If users toggle them, reflect the state but default remains off.
+- Transition guidance:
+  - Interception ON → user edits → may replay before resuming. Replay state machine still applies.
+  - Auto-apply ON → edits are applied automatically on later turns; replay remains a manual audit/fork tool.
+  - Replay does not alter interception/override settings; these modes are orthogonal and should be surfaced separately to avoid mode sprawl.

--- a/.kiro/specs/chat-timeline-replay/design.md
+++ b/.kiro/specs/chat-timeline-replay/design.md
@@ -24,7 +24,7 @@ When a user edits or deletes sections in the Live Request Editor and sends, offe
 3) **Invocation Surface**: Command (e.g., `github.copilot.liveRequestEditor.replayPrompt`) and/or button in the Live Request Editor banner, gated by feature flag.
 4) **Display Surface**: Render via chat participant/content provider in the chat panel; no model call. Replay is read-only by default; user must click “Start chatting from this replay” to enable input.
 5) **Fork payload**: Seed the forked session with the exact trimmed payload that was (or would be) sent to avoid divergence; use the richer projection for display only.
-6) **Persistence (future)**: If/when chat-history-persistence (SQLite) is enabled, store replay metadata (replay_parent_turn_id/session_id, trimmed payload hash, version) so forks survive reloads; otherwise replay remains in-memory only (optional one-level “restore previous replay” buffer per turn).
+6) **Persistence (future)**: If/when chat-history-persistence (SQLite) is enabled, store replay metadata (replay_parent_turn_id/session_id, trimmed payload hash, version) so forks survive reloads; otherwise replay remains in-memory only (keep a one-level “restore previous replay” buffer per turn).
 
 ### Data & Control Flow
 1. User edits and confirms send.
@@ -45,7 +45,8 @@ When a user edits or deletes sections in the Live Request Editor and sends, offe
 - Entry point: explicit “Replay edited prompt” action in the Live Request Editor banner. No surprise auto-launch; optional toast if auto-opened.
 - Option A (one fork per turn): a new replay replaces the previous fork for that turn. Optional soft safety net: keep the last replaced fork in memory for “Restore previous replay.”
 - When enabling input (continuing from fork), switch focus to the replay session and show a breadcrumb/toast indicating the fork.
-- Cap rendered sections (e.g., 30) and show “View replayed prompt (N more)” to avoid overloading the view.
+- Cap rendered sections (30) and show “View replayed prompt (N more)” to avoid overloading the view.
+- In replay/fork view, keep interception/auto-override off by default; expose a human toggle if needed. In off mode, disable edit/delete controls and auto-scroll to the latest section.
 
 ### Configuration / Flags
 - `github.copilot.chat.liveRequestEditor.timelineReplay.enabled` (default: false).
@@ -73,3 +74,18 @@ When a user edits or deletes sections in the Live Request Editor and sends, offe
 - How should interception/auto-override behave on the fork (inherit vs. start clean)?
 - If persistence is off, do we need a soft in-memory “Restore previous replay” buffer per turn, and how many versions to keep?
 - Do we keep interception/auto-override disabled by default on the fork, or allow opt-in inheritance?
+- Can we reduce modes to two user-facing states in replay: “View replay” (read-only) and “Start chatting from this replay” (continues fork), with interception/auto-override remaining off unless explicitly toggled?
+
+## Tiny Diagram
+
+```
+Live Request Editor (edits/undo/redo)
+        |
+        v
+ Replay Builder (projection, trimmed payload)
+        |
+        v
+ Replayed Session (chat view)
+   - Display-only by default
+   - “Start chatting from this replay” => enable input (fork)
+```

--- a/.kiro/specs/chat-timeline-replay/design.md
+++ b/.kiro/specs/chat-timeline-replay/design.md
@@ -23,11 +23,12 @@ When a user edits or deletes sections in the Live Request Editor and sends, offe
 2) **Replay Session Manager**: Create/reuse a forked “replayed prompt” conversation keyed to the source session/location; optionally link via `replay_parent_turn_id`.
 3) **Invocation Surface**: Command (e.g., `github.copilot.liveRequestEditor.replayPrompt`) and/or button in the Live Request Editor banner, gated by feature flag.
 4) **Display Surface**: Render via chat participant/content provider in the chat panel; no model call.
+5) **Persistence (future)**: If/when chat-history-persistence (SQLite) is enabled, store replay metadata (replay_parent_turn_id/session_id, trimmed payload hash, version) so forks survive reloads; otherwise replay remains in-memory only.
 
 ### Data & Control Flow
 1. User edits and confirms send.
 2. Build `ReplayChatSessionInit` from `EditableChatRequest.messages` (+ tool metadata, request options, intent/debug name).
-3. Create/update replay session; emit synthetic chat events to render bubbles in order:
+3. Create/update replay session (Option A: one fork per turn; replays replace the prior fork for that turn); emit synthetic chat events to render bubbles in order:
    - System/prefix → system bubble (collapsed default).
    - Context/history → user/assistant bubbles tagged “replayed.”
    - Tool calls/results → assistant/tool bubbles with arguments/results (no re-execution).
@@ -39,7 +40,9 @@ When a user edits or deletes sections in the Live Request Editor and sends, offe
 - Collapse long system/history/tool content by default; “View replayed prompt”/“Collapse” toggles.
 - Omit deleted sections; mark edited sections with an “Edited” chip.
 - Warn if prompt was token-trimmed: “Prompt was trimmed; replay may omit truncated content.”
-- Provide “Back to conversation” + “Open Live Request Editor” links.
+- Provide “Back to conversation” + “Open Live Request Editor” links. When read-only replay is shown, keep input disabled until the user explicitly chooses “Start chatting from this replay.”
+- Entry point: explicit “Replay edited prompt” action in the Live Request Editor banner. No surprise auto-launch; optional toast if auto-opened.
+- Option A (one fork per turn): a new replay replaces the previous fork for that turn. Optional soft safety net: keep the last replaced fork in memory for “Restore previous replay.”
 
 ### Configuration / Flags
 - `github.copilot.chat.liveRequestEditor.timelineReplay.enabled` (default: false).
@@ -65,3 +68,4 @@ When a user edits or deletes sections in the Live Request Editor and sends, offe
 - Should replays persist across reloads (ties to chat-history-persistence) or stay ephemeral?
 - Should focus auto-switch to the replay session or prompt first?
 - How should interception/auto-override behave on the fork (inherit vs. start clean)?
+- If persistence is off, do we need a soft in-memory “Restore previous replay” buffer per turn, and how many versions to keep?

--- a/.kiro/specs/chat-timeline-replay/flows.md
+++ b/.kiro/specs/chat-timeline-replay/flows.md
@@ -78,10 +78,11 @@ sequenceDiagram
     RS-->>User: Enable input, show breadcrumb/toast
     User->>RS: Type new message
     User->>RS: Send message
-    RS->>Fetcher: Send request with trimmed edited history + new user message
+    RS->>Fetcher: Send request (trimmed edited history + new user message)
     Fetcher->>Model: Invoke model
     Model-->>RS: Stream response
-    RS-->>User: Display response (replay session only; original session untouched)
+    RS-->>User: Display response
+    Note over RS: Replay session only; original session untouched
 ```
 
 ## Replay State Machine (per source turn/session)

--- a/.kiro/specs/chat-timeline-replay/flows.md
+++ b/.kiro/specs/chat-timeline-replay/flows.md
@@ -82,7 +82,7 @@ sequenceDiagram
     Fetcher->>Model: Invoke model
     Model-->>RS: Stream response
     RS-->>User: Display response
-    Note over RS: Replay session only; original session untouched
+    Note over RS: Replay session only\nOriginal session untouched
 ```
 
 ## Replay State Machine (per source turn/session)

--- a/.kiro/specs/chat-timeline-replay/flows.md
+++ b/.kiro/specs/chat-timeline-replay/flows.md
@@ -1,0 +1,78 @@
+# Replay Flows & Interrupt Handling
+
+## Use Case 1: Manual Replay (Read-only)
+
+- User edits prompt in Live Request Editor.
+- User clicks “Replay edited prompt.”
+- Replay session is created (read-only); no model call.
+- User reviews bubbles; may inspect diffs via hover action.
+- Optional: user clicks “Start chatting from this replay” to continue in the fork.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant LRE as Live Request Editor
+    participant RB as Replay Builder
+    participant RS as Replay Session (chat view)
+    participant Model
+
+    User->>LRE: Edit prompt sections
+    User->>LRE: Click "Replay edited prompt"
+    LRE->>RB: Build projection (trimmed payload)
+    RB-->>RS: Create/update replay session (read-only)
+    RS-->>User: Display replay bubbles (collapsed system/history, edited chips)
+    Note over RS: No model call<br/>Interception/auto-override off<br/>Edit/delete disabled
+    User->>RS: (Optional) Click "Start chatting from this replay"
+    RS-->>User: Enable input, show breadcrumb/toast<br/>(still no model call yet)
+```
+
+## Use Case 2: Intercept → Replay → Resume
+
+- User has “Pause & review” on (interception).
+- Send is intercepted; LRE is focused.
+- User edits; clicks “Replay edited prompt.”
+- Replay session is created (read-only); user reviews.
+- User resumes send (no fork), or optionally forks to continue in replay session.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant LRE as Live Request Editor
+    participant RB as Replay Builder
+    participant RS as Replay Session (chat view)
+    participant Fetcher as ChatML Fetcher
+    participant Model
+
+    User->>LRE: Send message (interception ON)
+    LRE-->>User: Intercepted banner
+    User->>LRE: Edit prompt
+    User->>LRE: Click "Replay edited prompt"
+    LRE->>RB: Build projection (trimmed payload)
+    RB-->>RS: Create/update replay session (read-only)
+    RS-->>User: Display replay bubbles
+    alt User resumes send
+        User->>LRE: Click "Resume send"
+        LRE->>Fetcher: Send trimmed edited payload
+        Fetcher->>Model: Invoke model
+    else User forks to chat from replay
+        User->>RS: Click "Start chatting from this replay"
+        RS-->>User: Enable input, show breadcrumb/toast
+        Note over RS,Fetcher: Original intercepted turn is still resumed/cancelled per user action
+    end
+```
+
+## Interrupt Handling (Graceful)
+
+- **Empty/invalid projection**: Show “Nothing to replay” with link back to LRE; do not create replay session.
+- **Mapping failure**: Show error toast; keep original session untouched.
+- **Trimmed prompt**: Show banner “Prompt was trimmed; replay may omit truncated content.”
+- **Interception state changes** (user cancels/turn discarded): Auto-dismiss replay session or mark it stale; keep original session intact.
+- **Re-replay on same turn**: Replace existing replay (Option A); keep one-level in-memory “Restore previous replay” if persistence is off.
+- **Concurrency** (multiple turns): One replay fork per source turn; labeling includes source session/turn. If user triggers replay on a new turn, switch context or show selector.
+- **Interception/auto-override in fork**: Off by default; if enabled manually, re-enable edit/delete and allow normal scroll; otherwise keep edit/delete disabled and auto-scroll to latest.
+
+## Defaults Recap
+- Caps: render up to 30 sections; show “(N more)” affordance.
+- Entry: explicit “Replay edited prompt” action; read-only by default.
+- Continue: “Start chatting from this replay” toggles input and focus with breadcrumb/toast.
+- One fork per turn; replay payload seeded from trimmed messages; projection is display-only.

--- a/.kiro/specs/chat-timeline-replay/flows.md
+++ b/.kiro/specs/chat-timeline-replay/flows.md
@@ -61,6 +61,29 @@ sequenceDiagram
     end
 ```
 
+## Use Case 3: Continue from Replay and Send
+
+- User in replay session clicks “Start chatting from this replay” (input enabled).
+- User composes a new message in the replay session and sends.
+- Forked session uses the trimmed edited history as context; no changes to original session.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant RS as Replay Session (chat view, forked)
+    participant Fetcher as ChatML Fetcher
+    participant Model
+
+    User->>RS: Click "Start chatting from this replay"
+    RS-->>User: Enable input, show breadcrumb/toast
+    User->>RS: Type new message
+    User->>RS: Send message
+    RS->>Fetcher: Send request with trimmed edited history + new user message
+    Fetcher->>Model: Invoke model
+    Model-->>RS: Stream response
+    RS-->>User: Display response (replay session only; original session untouched)
+```
+
 ## Interrupt Handling (Graceful)
 
 - **Empty/invalid projection**: Show “Nothing to replay” with link back to LRE; do not create replay session.

--- a/.kiro/specs/chat-timeline-replay/requirements.md
+++ b/.kiro/specs/chat-timeline-replay/requirements.md
@@ -22,6 +22,9 @@ Provide an opt-in chat timeline that mirrors the edited prompt (system/history/t
 - THE System SHALL label replay sessions as “Replayed prompt” and show source session/request identifiers in tooltip/description.
 - THE System SHALL mark edited sections with an “Edited” indicator and omit deleted sections.
 - THE System SHALL provide “View replayed prompt”/“Collapse” toggles for long sections and a link back to the Live Request Editor.
+- THE System SHALL cap rendered sections at 30 and expose a “View replayed prompt (N more)” affordance for additional sections.
+- THE System SHALL present the replay as read-only until the user chooses “Start chatting from this replay,” at which point input is enabled and focus shifts to the replay session with a breadcrumb/toast.
+- WHEN interception/auto-override are off in the fork, THEN edit/delete controls in the replay view SHALL be disabled and the view SHALL auto-scroll to the latest section.
 
 ### R4: Session Handling
 - THE System SHALL create or reuse a replay session keyed to the source session/location; original session remains intact.

--- a/.kiro/specs/chat-timeline-replay/requirements.md
+++ b/.kiro/specs/chat-timeline-replay/requirements.md
@@ -38,3 +38,4 @@ Provide an opt-in chat timeline that mirrors the edited prompt (system/history/t
 - THE System SHALL emit telemetry on replay invocation with source sessionId/requestId and counts of total/edited/deleted sections.
 - WHEN replay content cannot be built (e.g., mapping failure), THEN the System SHALL show an error message and avoid creating a replay session.
 - THE System SHOULD log parity mismatches when replay content differs from the last logged request, for diagnostics.
+- THE System SHOULD include version/hash metadata with replay builds and ignore stale updates in UI consumers; when replay/log hashes differ, a warning SHALL be surfaced in replay/metadata views.

--- a/.kiro/specs/chat-timeline-replay/requirements.md
+++ b/.kiro/specs/chat-timeline-replay/requirements.md
@@ -24,8 +24,10 @@ Provide an opt-in chat timeline that mirrors the edited prompt (system/history/t
 
 ### R4: Session Handling
 - THE System SHALL create or reuse a replay session keyed to the source session/location; original session remains intact.
+- THE System SHALL allow only one replay fork per source turn; a new replay for the same turn SHALL replace the previous fork (Option A).
 - WHEN a replay session is created, THEN the System SHOULD record a `replay_parent_turn_id` (or equivalent) for telemetry/persistence linkage.
 - THE System SHALL avoid invoking the model; replay is display-only unless explicitly extended in future scope.
+- WHEN chat history persistence (SQLite) is enabled, THEN the System SHOULD persist replay linkage/metadata so the fork survives reloads; otherwise the replay MAY remain in-memory only.
 
 ### R5: Telemetry and Errors
 - THE System SHALL emit telemetry on replay invocation with source sessionId/requestId and counts of total/edited/deleted sections.

--- a/.kiro/specs/chat-timeline-replay/requirements.md
+++ b/.kiro/specs/chat-timeline-replay/requirements.md
@@ -15,6 +15,7 @@ Provide an opt-in chat timeline that mirrors the edited prompt (system/history/t
 - THE System SHALL build replay content from `EditableChatRequest.messages`, preserving order and edited content, and omitting deleted sections.
 - WHEN sections were token-trimmed upstream, THEN the System SHALL surface a warning that replay may omit truncated content and reuse the same trimming/summarization applied during prompt render.
 - WHEN tool calls/results are present, THEN the System SHALL render tool bubbles with names and arguments/results marked “replayed.”
+- THE System SHALL seed the forked session with the exact trimmed payload that was/would be sent; the richer projection is for display only.
 
 ### R3: Display and UX
 - THE System SHALL render replay as chat bubbles (system/history/context/tool/user) with system/prefix collapsed by default.
@@ -25,6 +26,7 @@ Provide an opt-in chat timeline that mirrors the edited prompt (system/history/t
 ### R4: Session Handling
 - THE System SHALL create or reuse a replay session keyed to the source session/location; original session remains intact.
 - THE System SHALL allow only one replay fork per source turn; a new replay for the same turn SHALL replace the previous fork (Option A).
+- THE System SHALL keep replay display-only by default and enable input only after the user chooses to continue (“Start chatting from this replay”).
 - WHEN a replay session is created, THEN the System SHOULD record a `replay_parent_turn_id` (or equivalent) for telemetry/persistence linkage.
 - THE System SHALL avoid invoking the model; replay is display-only unless explicitly extended in future scope.
 - WHEN chat history persistence (SQLite) is enabled, THEN the System SHOULD persist replay linkage/metadata so the fork survives reloads; otherwise the replay MAY remain in-memory only.

--- a/.kiro/specs/chat-timeline-replay/tasks.md
+++ b/.kiro/specs/chat-timeline-replay/tasks.md
@@ -31,7 +31,16 @@
 
 - [ ] 4. Tests and validation
   - Unit tests for projection (ordering, deletions/edits, tool labeling, trimming warnings).
-  - Integration tests for command → session creation → rendering.
-  - UX validation for collapsed sections, labels, and navigation back to Live Request Editor.
-  - If persistence is enabled, add tests for replay metadata save/load and version replacement (Option A).
-  - Tests for version/hash scoping: stale updates ignored; parity warning surfaced on hash mismatch; stale/cleared handling on context change/cancel.
+  - Unit tests for version/hash scoping: stale updates ignored; replay_replace replaces prior fork; restore_previous buffer (if enabled) works.
+  - Integration tests:
+    - Command availability when LRE is enabled/disabled or no editable request exists (shows “Nothing to replay”).
+    - Replay render: collapsed system/history/tool, edited chips, section cap (30) with “(N more)” affordance, warning on trimmed prompt.
+    - “Start chatting from this replay”: enables input, shifts focus with breadcrumb/toast, sends with trimmed edited history + new message; original session untouched.
+    - Interception ON: paused send → edit → replay → resume send uses trimmed edited payload; fork path still works.
+    - Auto-override ON: prefix edits auto-applied; replay remains manual audit/fork; no change to send semantics.
+    - Interception/override OFF in replay by default: edit/delete disabled; auto-scroll to latest section.
+    - Context change/cancel: replay marked stale; input disabled; cleared message shown.
+    - Replay replace on same turn: prior replay replaced; optional restore buffer tested.
+  - UX validation for collapsed sections, labels, navigation back to LRE, and stale state messaging.
+  - Telemetry tests: emits source session/turn, section counts, hashes; parity warning emitted on hash mismatch.
+  - If persistence is enabled: tests for replay metadata save/load (parent IDs, hash, version) and replace behavior (Option A).

--- a/.kiro/specs/chat-timeline-replay/tasks.md
+++ b/.kiro/specs/chat-timeline-replay/tasks.md
@@ -4,6 +4,7 @@
   - Decide read-only vs. forkable replay session.
   - Confirm collapse defaults and “Edited” labeling.
   - Set flag name (`github.copilot.chat.liveRequestEditor.timelineReplay.enabled`).
+  - Note dependency: persistence is optional. If chat-history-persistence (SQLite) is off, forks are in-memory only; if on, store replay metadata (parent IDs, hashes, version) so forks survive reloads.
 
 - [ ] 1. Build replay projection
   - Map `EditableChatRequest.messages` → replay bubbles (system/history/tool/user).
@@ -12,6 +13,7 @@
 
 - [ ] 2. Session creation and rendering
   - Add replay session manager keyed to source session/location with optional `replay_parent_turn_id`.
+  - Enforce Option A: one replay fork per source turn; replace prior fork if re-replayed.
   - Expose command `github.copilot.liveRequestEditor.replayPrompt` and surface in Live Request Editor UI.
   - Render bubbles via chat participant/content provider without model invocation.
 
@@ -24,3 +26,4 @@
   - Unit tests for projection (ordering, deletions/edits, tool labeling, trimming warnings).
   - Integration tests for command → session creation → rendering.
   - UX validation for collapsed sections, labels, and navigation back to Live Request Editor.
+  - If persistence is enabled, add tests for replay metadata save/load and version replacement (Option A).

--- a/.kiro/specs/chat-timeline-replay/tasks.md
+++ b/.kiro/specs/chat-timeline-replay/tasks.md
@@ -12,6 +12,7 @@
   - Omit deleted sections; mark edited sections; collapse long system/history/tool by default.
   - Include tool call/result labels and trimmed-prompt warning when applicable.
   - Enforce section cap (30) and compute “(N more)” affordance for overflow.
+  - Attach version/hash metadata to replay builds; emit with session scoping for consumers.
 
 - [ ] 2. Session creation and rendering
   - Add replay session manager keyed to source session/location with optional `replay_parent_turn_id`.
@@ -21,6 +22,7 @@
   - When continuing from replay, switch focus to the replay session and show breadcrumb/toast. Keep interception/auto-override off by default in the fork unless explicitly enabled.
   - Cap rendered sections (e.g., 30) and provide “View replayed prompt (N more)” affordance.
   - In replay view with interception off, disable edit/delete controls and auto-scroll to the latest section.
+  - Handle stale/cleared states (canceled send/context switch) by marking replay stale; ignore stale updates (version/hash guard).
 
 - [ ] 3. Telemetry and error handling
   - Emit invocation telemetry with source sessionId/requestId and section counts.
@@ -32,3 +34,4 @@
   - Integration tests for command → session creation → rendering.
   - UX validation for collapsed sections, labels, and navigation back to Live Request Editor.
   - If persistence is enabled, add tests for replay metadata save/load and version replacement (Option A).
+  - Tests for version/hash scoping: stale updates ignored; parity warning surfaced on hash mismatch; stale/cleared handling on context change/cancel.

--- a/.kiro/specs/chat-timeline-replay/tasks.md
+++ b/.kiro/specs/chat-timeline-replay/tasks.md
@@ -5,6 +5,7 @@
   - Confirm collapse defaults and “Edited” labeling.
   - Set flag name (`github.copilot.chat.liveRequestEditor.timelineReplay.enabled`).
   - Note dependency: persistence is optional. If chat-history-persistence (SQLite) is off, forks are in-memory only; if on, store replay metadata (parent IDs, hashes, version) so forks survive reloads.
+  - Default: replay starts read-only; user clicks “Start chatting from this replay” to enable input. Fork payload uses the trimmed messages that were/would be sent.
 
 - [ ] 1. Build replay projection
   - Map `EditableChatRequest.messages` → replay bubbles (system/history/tool/user).
@@ -16,6 +17,8 @@
   - Enforce Option A: one replay fork per source turn; replace prior fork if re-replayed.
   - Expose command `github.copilot.liveRequestEditor.replayPrompt` and surface in Live Request Editor UI.
   - Render bubbles via chat participant/content provider without model invocation.
+  - When continuing from replay, switch focus to the replay session and show breadcrumb/toast. Keep interception/auto-override off by default in the fork unless explicitly enabled.
+  - Cap rendered sections (e.g., 30) and provide “View replayed prompt (N more)” affordance.
 
 - [ ] 3. Telemetry and error handling
   - Emit invocation telemetry with source sessionId/requestId and section counts.

--- a/.kiro/specs/chat-timeline-replay/tasks.md
+++ b/.kiro/specs/chat-timeline-replay/tasks.md
@@ -11,6 +11,7 @@
   - Map `EditableChatRequest.messages` → replay bubbles (system/history/tool/user).
   - Omit deleted sections; mark edited sections; collapse long system/history/tool by default.
   - Include tool call/result labels and trimmed-prompt warning when applicable.
+  - Enforce section cap (30) and compute “(N more)” affordance for overflow.
 
 - [ ] 2. Session creation and rendering
   - Add replay session manager keyed to source session/location with optional `replay_parent_turn_id`.
@@ -19,6 +20,7 @@
   - Render bubbles via chat participant/content provider without model invocation.
   - When continuing from replay, switch focus to the replay session and show breadcrumb/toast. Keep interception/auto-override off by default in the fork unless explicitly enabled.
   - Cap rendered sections (e.g., 30) and provide “View replayed prompt (N more)” affordance.
+  - In replay view with interception off, disable edit/delete controls and auto-scroll to the latest section.
 
 - [ ] 3. Telemetry and error handling
   - Emit invocation telemetry with source sessionId/requestId and section counts.

--- a/.kiro/specs/request-logger-prompt-editor/design.md
+++ b/.kiro/specs/request-logger-prompt-editor/design.md
@@ -552,6 +552,13 @@ See `.kiro/specs/chat-history-persistence` for the detailed design/requirements/
 
 See `.kiro/specs/graphiti-memory-integration` for the detailed design/requirements/tasks of the optional Graphiti ingestion concept (feature-gated network sync).
 
+## UI Simplification Opportunities (Forward-Looking)
+
+- Lean on replay/fork as the primary “advanced” affordance: keep replay display-only by default with an explicit “Start chatting from this replay” to avoid branching confusion.
+- Keep interception/auto-override UI minimal: a single “Pause & review” toggle plus an “Auto-apply edits” entry; avoid mode sprawl.
+- Prefer banner actions over nested menus; reserve hover toolbars for section-level edits only.
+- When replay is available, consider demoting inline diff/restore affordances in the main view to reduce clutter (surface them as hover/secondary actions).
+
 ## Future Enhancements
 
 - Side-by-side diff view: auto-generated vs edited prompt.

--- a/docs/replay-handoff.md
+++ b/docs/replay-handoff.md
@@ -1,0 +1,45 @@
+# Chat Timeline Replay – Handoff (8 Dec 2025)
+
+Branch: `feature/spec-refactor` (spec-only; no code changes yet)
+
+## Source of Truth
+- `.kiro/specs/chat-timeline-replay/{design.md,requirements.md,tasks.md,flows.md}` — replay/fork UX, state machine, caps, sync/parity rules.
+- `.kiro/specs/request-logger-prompt-editor/design.md` — overall Live Request Editor architecture; replay is additive/orthogonal to interception/auto-override.
+
+## Next Implementation Tasks (can run in parallel)
+1) **Replay builder + service plumbing**
+   - Implement projection/state machine in the service layer with version/hash guards, Option A (one fork per turn), and the one-level restore buffer.
+   - Seed fork payload from trimmed messages; projection is display-only.
+   - Add `replay_parent_session_id` / `replay_parent_turn_id` linkage and stale handling on cancel/context change.
+   - Likely files: `src/extension/prompt/node/liveRequestEditorService.ts`, `src/extension/prompt/node/liveRequestBuilder.ts`, tests under `src/extension/prompt/node/test/`.
+
+2) **Chat view integration (command + rendering)**
+   - Add `replayPrompt` command entry point and surface “Replay edited prompt” in the Live Request Editor UI.
+   - Render replay in chat view: collapsed system/history/tool, edited chips, section cap=30 with “(N more)”, trimmed warning, read-only by default; “Start chatting from this replay” enables input + focus shift with breadcrumb/toast.
+   - Disable edit/delete in replay view when interception/override are off; auto-scroll to latest.
+   - Likely files: `src/extension/prompt/vscode-node/liveRequestEditorProvider.ts`, `src/extension/prompt/webview/vscode/liveRequestEditor/main.tsx` (if reused), chat participant/content provider hookup.
+
+3) **Telemetry, parity, persistence hooks**
+   - Emit replay invocation telemetry (session/turn, totals/edited/deleted, hashes) and parity warnings when replay hash ≠ logged hash.
+   - Persist replay metadata (parent IDs, hash, version) when chat-history-persistence (SQLite) is enabled; otherwise keep the one-level restore buffer.
+   - Surface parity/stale warnings in replay/metadata views.
+   - Likely files: service + telemetry plumbing, `src/platform/configuration/common/configurationService.ts` (flags), persistence layer once implemented.
+
+## Ready State / Defaults
+- Modes: replay off by default; read-only entry, user must click “Start chatting from this replay” to fork. Interception/auto-override stay off in replay unless explicitly toggled.
+- Cap: 30 sections; “(N more)” affordance for overflow. Trimmed payload is the fork seed; projection is display-only.
+- One fork per turn; replay_replace replaces prior replay; optional one-level restore buffer.
+- States: `idle → building → replay_ready → fork_active → stale` (see `flows.md` for mermaid).
+
+## Testing Pointers
+- Unit: projection mapping, caps, edited/deleted handling, version/hash guards, replay_replace/restore buffer, state machine transitions.
+- Integration: command availability, rendering (collapsed/edited/cap, trimmed warning), “Start chatting” flow (focus shift, trimmed history send, original session untouched), interception on/off, auto-override on, stale handling on cancel/context change, replace replay on same turn.
+- Telemetry/parity: events contain session/turn, counts, hashes; parity warning on hash mismatch.
+- Persistence (when available): save/load replay metadata and replace behavior (Option A).
+
+## Interrupt Handling (per spec)
+- Empty/invalid projection: show “Nothing to replay”; no session created.
+- Mapping failure: toast; original session untouched.
+- Trimmed prompt: banner.
+- Context change/cancel: mark replay stale; disable input; show cleared state.
+- Re-replay same turn: replace prior; optionally allow “Restore previous replay” (last version only).


### PR DESCRIPTION
This pull request updates the replay workflow and requirements for the Live Request Editor, clarifying the replay/fork session model, read-only states, persistence, and UX affordances. The changes introduce a clearer separation between display-only replay sessions and forked sessions with input, enforce section caps, and specify how replay metadata is handled for persistence. The documentation now includes detailed flows, error handling, and forward-looking UI simplification opportunities.

**Replay Session Model and UX:**
* Replay sessions are display-only by default; users must explicitly click “Start chatting from this replay” to enable input and continue in a forked session. Only one replay fork per source turn is allowed, replacing prior forks if re-replayed. [[1]](diffhunk://#diff-c103c0289e637eebfe703b1bdbcb596df9298e30732640a1d2bef61b465eb0abL25-R49) [[2]](diffhunk://#diff-45b2339bb95caf180424042fc5c76bf5c2973791e88b82c5ef5dff21ef99acdeR18-R35)
* The forked session is seeded with the exact trimmed payload that was or would be sent, while the richer replay projection is used for display. [[1]](diffhunk://#diff-45b2339bb95caf180424042fc5c76bf5c2973791e88b82c5ef5dff21ef99acdeR18-R35) [[2]](diffhunk://#diff-36097b570fa8ac828bd5c48b9869a5a09c50cc7d57075a7b10db487320bfe232R7-R23)

**Persistence and Session Handling:**
* If chat-history persistence (SQLite) is enabled, replay metadata (parent turn/session IDs, hashes, version) is stored so forks survive reloads; otherwise, replays remain in-memory with a one-level “restore previous replay” buffer per turn. [[1]](diffhunk://#diff-c103c0289e637eebfe703b1bdbcb596df9298e30732640a1d2bef61b465eb0abL25-R49) [[2]](diffhunk://#diff-36097b570fa8ac828bd5c48b9869a5a09c50cc7d57075a7b10db487320bfe232R7-R23) [[3]](diffhunk://#diff-36097b570fa8ac828bd5c48b9869a5a09c50cc7d57075a7b10db487320bfe232R34)
* Replay session management enforces Option A: one replay fork per source turn, replacing the prior fork if re-replayed. [[1]](diffhunk://#diff-c103c0289e637eebfe703b1bdbcb596df9298e30732640a1d2bef61b465eb0abL25-R49) [[2]](diffhunk://#diff-36097b570fa8ac828bd5c48b9869a5a09c50cc7d57075a7b10db487320bfe232R7-R23)

**Display and Section Limits:**
* Rendered replay sections are capped at 30, with a “View replayed prompt (N more)” affordance for overflow. Edited sections are labeled, deleted sections omitted, and long content collapsed by default. [[1]](diffhunk://#diff-45b2339bb95caf180424042fc5c76bf5c2973791e88b82c5ef5dff21ef99acdeR18-R35) [[2]](diffhunk://#diff-36097b570fa8ac828bd5c48b9869a5a09c50cc7d57075a7b10db487320bfe232R7-R23)

**Interception and Controls:**
* Interception/auto-override is off by default in the fork; edit/delete controls are disabled and the view auto-scrolls to the latest section unless interception is explicitly enabled. [[1]](diffhunk://#diff-c103c0289e637eebfe703b1bdbcb596df9298e30732640a1d2bef61b465eb0abL25-R49) [[2]](diffhunk://#diff-45b2339bb95caf180424042fc5c76bf5c2973791e88b82c5ef5dff21ef99acdeR18-R35) [[3]](diffhunk://#diff-36097b570fa8ac828bd5c48b9869a5a09c50cc7d57075a7b10db487320bfe232R7-R23)

**Documentation and UI Simplification:**
* Added replay flows, error/interrupt handling, and a summary diagram. Forward-looking UI suggestions favor replay/fork as the main advanced affordance, minimize mode sprawl, and reduce inline diff/restore clutter. [[1]](diffhunk://#diff-1168737f101fd7cc1d022fe002a10cbf14bcd502feb365a26c6537b7bd7d37d0R1-R78) [[2]](diffhunk://#diff-a6c5213aa3fbea0e474c4f10d21a668c3e807d4a8d0376c59588834e071541baR555-R561) [[3]](diffhunk://#diff-c103c0289e637eebfe703b1bdbcb596df9298e30732640a1d2bef61b465eb0abR75-R91)