### PR TITLE
ci: build before packaging vsix

### DIFF
--- a/.github/workflows/publish-vsix.yml
+++ b/.github/workflows/publish-vsix.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build extension
+        run: NODE_OPTIONS=--experimental-strip-types npm run build
+
       - name: Build VSIX
         run: npm run package
 


### PR DESCRIPTION
## Summary
- hydrate simulation cache before build
- build extension prior to packaging so vsce finds dist/extension

## Testing
- NODE_OPTIONS=--experimental-strip-types npm run build
- npm run package