### PR TITLE
docs: rebrand readme and add custom icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,38 @@
-# GitHub Copilot - Your AI peer programmer
+# Company Copilot Chat (intranet build)
 
-**[GitHub Copilot](https://code.visualstudio.com/docs/copilot/overview)** is an AI peer programming tool that helps you write code faster and smarter.
+This fork of `GitHub.copilot-chat` is published only inside our intranet. It keeps upstream Copilot Chat behavior but adds:
+- VSIX build hardened for offline/intranet CI (cache hydration + explicit build step + direct `vsce` packaging).
+- Internal branding (muscular Octocat icon) and per-view icons to make the UI easier to spot in our toolset.
+- Documentation tailored for private distribution and updates.
 
-GitHub Copilot adapts to your unique needs allowing you to select the best model for your project, customize chat responses with custom instructions, and utilize agent mode for AI-powered, seamlessly integrated peer programming sessions.
+## Installing and getting updates
+- Download the latest `.vsix` from the internal share (or GitHub release on our fork) and run `Extensions: Install from VSIX…` in VS Code.
+- To notify teammates about new builds, share the release link and/or set up an internal channel (Teams/Slack/email) with the VSIX URL. If you maintain a private extension gallery, add it to `settings.json`:
+  ```json
+  {
+    "extensions.gallery": {
+      "serviceUrl": "https://your-intranet-gallery.example.com/_apis/public/gallery",
+      "cacheUrl": "https://your-intranet-gallerycache.example.com",
+      "itemUrl": "https://your-intranet-gallery.example.com/items"
+    },
+    "extensions.autoUpdate": true
+  }
+  ```
+- Scripted updates for dev machines/CI: `code --install-extension ./copilot-chat-*.vsix --force`.
 
-**Sign up for [GitHub Copilot Free](https://github.com/settings/copilot?utm_source=vscode-chat-readme&utm_medium=first&utm_campaign=2025mar-em-MSFT-signup)!**
+## What’s different from upstream
+- Workflow: `publish-vsix` now hydrates the simulation cache, builds with `NODE_OPTIONS=--experimental-strip-types`, and calls `vsce package` directly (no reliance on stripped scripts).
+- Branding: new strong Octocat icon for the extension and custom icons for each contributed view (Chat Debug, Context Inspector, Live Request Metadata/Editor, Subagent Prompt Monitor).
+- Docs: this README focuses on internal usage; upstream marketing/telemetry copy removed.
 
-![Working with GitHub Copilot agent mode to make edits to code in your workspace](https://github.com/microsoft/vscode-copilot-release/blob/main/images/hero-dark.png?raw=true)
+## Views and icons
+- Chat Debug: `assets/icon-chat-debug.svg`
+- Context Inspector: `assets/icon-context-inspector.svg`
+- Live Request Metadata: `assets/icon-live-request-metadata.svg`
+- Live Request Editor: `assets/icon-live-request-editor.svg`
+- Subagent Prompt Monitor: `assets/icon-subagent-monitor.svg`
+- Extension icon: `assets/icon-strong-octocat.svg` (replaces the stock Copilot glyph)
 
-When you install Copilot in Visual Studio Code, you get two extensions:
-* **[GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot)** - Provides inline coding suggestions as you type.
-* **[GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat)** (this extension) - A companion extension that provides conversational AI assistance.
-
-## Getting access to GitHub Copilot
-
-Sign up for [GitHub Copilot Free](https://github.com/settings/copilot?utm_source=vscode-chat-readme&utm_medium=second&utm_campaign=2025mar-em-MSFT-signup), or request access from your enterprise admin.
-
-To access GitHub Copilot, an active GitHub Copilot subscription is required. You can read more about our business and individual offerings at [github.com/features/copilot](https://github.com/features/copilot?utm_source=vscode-chat&utm_medium=readme&utm_campaign=2025mar-em-MSFT-signup).
-
-## AI-powered coding sessions
-
-**Start an AI-powered coding session tailored to your workflow**. Copilot Edits allows you to quickly iterate on code changes directly in the editor, across multiple files using natural language. For a more autonomous peer programmer experience,
-[agent mode](https://aka.ms/vscode-copilot-agent) performs multi-step coding tasks at your command. It automatically handles compile and lint errors, monitors terminal and test output, and iterates until the task is complete. [Edit mode](https://aka.ms/vscode-copilot-edit) offers a conversational, step-by-step coding experience. Engage in multi-turn chat conversations while Copilot applies edits directly to your codebase, allowing you to review changes in context and maintain full control.
-
-![Agent mode in Copilot Chat creating a new Vue application](https://github.com/microsoft/vscode-copilot-release/blob/main/images/agent-mode-readme.gif?raw=true)
-
-## Inline suggestions in the editor
-
-**Automatically receive inline suggestions in the editor** from [ghost text suggestions](https://aka.ms/vscode-completions) and [next edit suggestions](https://aka.ms/vscode-nes) to help you write code faster. Ghost text suggestions provide suggestions at the current location, tailored to your coding style and your existing code. Copilot next edit suggestions (Copilot NES) takes it a step further and predicts what and where your next logical code change will be. Use the Tab key to navigate and accept changes in quick succession.
-
-![Copilot next edit suggestions](https://code.visualstudio.com/assets/docs/copilot/inline-suggestions/nes-point.gif)
-
-## Ask and learn about your code with chat
-
-**Ask Copilot for help with any task or question** in the [Chat view](https://aka.ms/vscode-chat), bringing in code from your current files. Rather than giving you a generic answer, it can give answers that are relevant for your codebase using information provided by [participants](https://aka.ms/vscode-chat-participants), [variables](https://aka.ms/vscode-chat-variables), and [slash commands](https://aka.ms/vscode-chat-commands).
-
-![Using the workspace chat participant](https://github.com/microsoft/vscode-copilot-release/blob/main/images/participants-workspace.gif?raw=true)
-
-**Apply Copilot's AI suggestions directly to your code** using [Inline chat](https://aka.ms/vscode-inline-chat), staying in the flow. Need help with refactoring a method, adding error handling, or explaining a complex algorithm - just launch Copilot in the editor!
-
-![Inline chat in VS Code](https://code.visualstudio.com/assets/docs/copilot/copilot-chat/inline-chat-question-example.png)
-
-### Supported languages and frameworks
-
-GitHub Copilot works on any language, including Java, PHP, Python, JavaScript, Ruby, Go, C#, or C++. Because it’s been trained on languages in public repositories, it works for most popular languages, libraries and frameworks.
-
-### Version compatibility
-
-As Copilot Chat releases in lockstep with VS Code due to its deep UI integration, every new version of Copilot Chat is only compatible with the latest and newest release of VS Code. This means that if you are using an older version of VS Code, you will not be able to use the latest Copilot Chat.
-
-Only the latest Copilot Chat versions will use the latest models provided by the Copilot service, as even minor model upgrades require prompt changes and fixes in the extension.
-
-### Privacy and preview terms
-
-By using Copilot Chat you agree to [GitHub Copilot chat preview terms](https://docs.github.com/en/early-access/copilot/github-copilot-chat-technical-preview-license-terms). Review the [transparency note](https://aka.ms/CopilotChatTransparencyNote) to understand about usage, limitations and ways to improve Copilot Chat during the technical preview.
-
-Your code is yours. We follow responsible practices in accordance with our [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement) to ensure that your code snippets will not be used as suggested code for other users of GitHub Copilot.
-
-To get the latest security fixes, please use the latest version of the Copilot extension and VS Code.
-
-### Resources & next steps
-* **Sign up for [GitHub Copilot Free](https://github.com/settings/copilot?utm_source=vscode-chat-readme&utm_medium=third&utm_campaign=2025mar-em-MSFT-signup)**
-    * If you're using Copilot for your business, check out [Copilot Business](https://docs.github.com/en/copilot/copilot-business/about-github-copilot-business) and [Copilot Enterprise](https://docs.github.com/en/copilot/github-copilot-enterprise/overview/about-github-copilot-enterprise)
-* **[Get started with Copilot in VS Code tutorial](https://code.visualstudio.com/docs/copilot/getting-started)**
-* **[Copilot Chat quickstart video](https://www.youtube.com/watch?v=3surPGP7_4o)** to learn Copilot Chat in less than 4 minutes
-* **[VS Code Copilot Series on YouTube](https://www.youtube.com/playlist?list=PLj6YeMhvp2S5_hvBl2SE-7YCHYlLQ0bPt)**
-* **[FAQ](https://code.visualstudio.com/docs/copilot/faq)**
-* **[Feedback](https://github.com/microsoft/vscode-copilot-release/issues)**: We'd love to get your help in making GitHub Copilot better!
-
-## Data and telemetry
-
-The GitHub Copilot Extension for Visual Studio Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more. This extension respects the `telemetry.telemetryLevel` setting which you can learn more about at https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.
-
-## Trademarks
-
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow Microsoft's Trademark & Brand Guidelines. Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
-
-## License
-
-Copyright (c) Microsoft Corporation. All rights reserved.
-
-Licensed under the [MIT](LICENSE.txt) license.
+## Notes
+- This fork still uses upstream Copilot services; keep VS Code on the latest stable for compatibility.
+- If you further customize models, endpoints, or telemetry, document the deltas here before shipping new VSIX builds.

--- a/assets/icon-chat-debug.svg
+++ b/assets/icon-chat-debug.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <style>
+      .stroke { stroke: #0f172a; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .fill { fill: #0f172a; }
+    </style>
+  </defs>
+  <rect x="2" y="4" width="22" height="16" rx="3" class="stroke"/>
+  <path class="stroke" d="M10 24h6l6 4v-4"/>
+  <circle cx="11" cy="12" r="1.5" class="fill"/>
+  <circle cx="16" cy="12" r="1.5" class="fill"/>
+  <circle cx="21" cy="12" r="1.5" class="fill"/>
+  <path class="stroke" d="M26 6l4-4"/>
+  <path class="stroke" d="M28 10.5V4"/>
+  <path class="stroke" d="M30.5 8H24"/>
+</svg>

--- a/assets/icon-context-inspector.svg
+++ b/assets/icon-context-inspector.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <style>
+      .stroke { stroke: #0f172a; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .fill { fill: #0f172a; }
+    </style>
+  </defs>
+  <rect x="4" y="6" width="18" height="6" rx="2" class="stroke"/>
+  <rect x="4" y="14" width="18" height="6" rx="2" class="stroke"/>
+  <path class="stroke" d="M14 20l6.5 6.5"/>
+  <circle cx="23.5" cy="23.5" r="3.5" class="stroke"/>
+  <circle cx="10" cy="9" r="1" class="fill"/>
+  <circle cx="10" cy="17" r="1" class="fill"/>
+</svg>

--- a/assets/icon-live-request-editor.svg
+++ b/assets/icon-live-request-editor.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <style>
+      .stroke { stroke: #0f172a; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .fill { fill: #0f172a; }
+    </style>
+  </defs>
+  <rect x="3" y="6" width="18" height="14" rx="3" class="stroke"/>
+  <path class="stroke" d="M8 13h8M8 10.5h5"/>
+  <path class="stroke" d="M6 22h9l4 4v-4"/>
+  <path class="stroke" d="M19 6.5l4-4 6 6-4 4h-3v-3z"/>
+  <path class="stroke" d="M22 6.5l3 3"/>
+</svg>

--- a/assets/icon-live-request-metadata.svg
+++ b/assets/icon-live-request-metadata.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <style>
+      .stroke { stroke: #0f172a; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .fill { fill: #0f172a; }
+    </style>
+  </defs>
+  <rect x="4" y="6" width="18" height="14" rx="3" class="stroke"/>
+  <path class="stroke" d="M7 22h9l4 4v-4"/>
+  <circle cx="23.5" cy="10.5" r="4" class="stroke"/>
+  <path class="stroke" d="M23.5 8v2.5"/>
+  <circle cx="23.5" cy="13.2" r="0.8" class="fill"/>
+</svg>

--- a/assets/icon-strong-octocat.svg
+++ b/assets/icon-strong-octocat.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <style>
+      .stroke { stroke: #111827; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }
+      .fill { fill: #111827; }
+    </style>
+  </defs>
+  <rect x="2.5" y="2.5" width="59" height="59" rx="12" fill="#f5f7fb" stroke="#111827" stroke-width="3"/>
+  <path class="stroke" d="M20.5 27.5v-8l8 6.5 8-6.5v8c0 6.5-4.5 12.5-8 12.5s-8-6-8-12.5Z"/>
+  <circle class="fill" cx="26" cy="27" r="2.5"/>
+  <circle class="fill" cx="38" cy="27" r="2.5"/>
+  <path class="stroke" d="M28 36c2 1 6 1 8 0"/>
+  <path class="stroke" d="M17 35c-4 0-7.5 3.5-7.5 7.5 0 3.5 2.5 6.5 6 7.5M11 42l4 2.5"/>
+  <path class="stroke" d="M47 35c4 0 7.5 3.5 7.5 7.5 0 3.5-2.5 6.5-6 7.5M53 42l-4 2.5"/>
+  <path class="stroke" d="M22 44c-1 3-3.5 5.5-6.5 6.5"/>
+  <path class="stroke" d="M42 44c1 3 3.5 5.5 6.5 6.5"/>
+  <path class="stroke" d="M24 50c3 1.5 13 1.5 16 0"/>
+</svg>

--- a/assets/icon-subagent-monitor.svg
+++ b/assets/icon-subagent-monitor.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <style>
+      .stroke { stroke: #0f172a; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .fill { fill: #0f172a; }
+    </style>
+  </defs>
+  <circle cx="16" cy="9" r="3" class="stroke"/>
+  <circle cx="8" cy="21" r="3" class="stroke"/>
+  <circle cx="24" cy="21" r="3" class="stroke"/>
+  <path class="stroke" d="M13.5 10.5 9.5 18M18.5 10.5 22.5 18"/>
+  <path class="stroke" d="M11 22.5c1.5 1.2 3.2 1.8 5 1.8s3.5-.6 5-1.8"/>
+  <path class="stroke" d="M14 21s.8 1 2 1 2-1 2-1"/>
+  <circle cx="16" cy="21" r="0.6" class="fill"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/microsoft/vscode/issues"
 	},
 	"qna": "https://github.com/github-community/community/discussions/categories/copilot",
-	"icon": "assets/copilot.png",
+	"icon": "assets/icon-strong-octocat.svg",
 	"pricing": "Trial",
 	"engines": {
 		"vscode": "^1.108.0",
@@ -4847,7 +4847,7 @@
 				{
 					"id": "copilot-chat",
 					"name": "Chat Debug",
-					"icon": "assets/debug-icon.svg",
+					"icon": "assets/icon-chat-debug.svg",
 					"when": "github.copilot.chat.showLogView"
 				}
 			],
@@ -4855,7 +4855,7 @@
 				{
 					"id": "context-inspector",
 					"name": "Language Context Inspector",
-					"icon": "$(inspect)",
+					"icon": "assets/icon-context-inspector.svg",
 					"when": "github.copilot.chat.showContextInspectorView"
 				}
 			],
@@ -4877,20 +4877,20 @@
 				{
 					"id": "github.copilot.liveRequestMetadata",
 					"name": "Live Request Metadata",
-					"icon": "assets/live-request-editor.svg",
+					"icon": "assets/icon-live-request-metadata.svg",
 					"when": "github.copilot-chat.activated && config.github.copilot.advanced.livePromptEditorEnabled"
 				},
 				{
 					"id": "github.copilot.liveRequestEditor",
 					"name": "Live Request Editor",
 					"type": "webview",
-					"icon": "assets/live-request-editor.svg",
+					"icon": "assets/icon-live-request-editor.svg",
 					"when": "github.copilot-chat.activated && config.github.copilot.advanced.livePromptEditorEnabled"
 				},
 				{
 					"id": "github.copilot.subagentPromptMonitor",
 					"name": "Subagent Prompt Monitor",
-					"icon": "assets/live-request-editor.svg",
+					"icon": "assets/icon-subagent-monitor.svg",
 					"when": "github.copilot-chat.activated && config.github.copilot.advanced.livePromptEditorEnabled"
 				}
 			]


### PR DESCRIPTION
## Summary
- rebrand README for intranet build
- add strong octocat extension icon and per-view icons
- keep publish workflow fixes already on main

## Testing
- NODE_OPTIONS=--experimental-strip-types npm run build
- npm exec vsce package