### PR TITLE
ci(upstream): date-stamp nightly sync PR titles

### DIFF
--- a/agent-prompt.md
+++ b/agent-prompt.md
@@ -162,6 +162,10 @@ When asked to “write the spec” or “create the core documents” for a feat
   - **Scope drift protocol** (when a new, unrelated scope appears mid-branch):
     1. STOP adding more changes in the new scope.
     2. Prefer isolating scopes with **`git worktree`** (so you can continue the current PR while starting a clean branch for the new scope):
+       - Worktree path convention (consistent across machines):
+         - Use a sibling directory: `../<repo>.worktrees/<branchSlug>`
+         - Example: `../vscode-copilot-chat.worktrees/fix-amend-merged-pr-commit-messages`
+         - Where `branchSlug` is the branch name with `/` replaced by `-`.
        - If you have not started the new work yet:
          - `git fetch origin && git worktree add -b <type>/<name> ../<repo>-<name> origin/main`
        - If you already have WIP changes for the new scope in the current worktree:

--- a/agent-prompt.md
+++ b/agent-prompt.md
@@ -148,9 +148,33 @@ When asked to “write the spec” or “create the core documents” for a feat
 ## Working Agreement & Workflow
 
 - **Branches & Commits**
-  - Default to feature branches named `feature/<short-feature-name>` (kebab-case).
+  - Default to branches named `<type>/<short-scope-name>` (kebab-case), for example:
+    - `feature/...` (new user-facing capability)
+    - `fix/...` (bug fix)
+    - `docs/...` (documentation only)
+    - `ci/...` (workflows/automation)
+    - `chore/...` (maintenance, build tooling, dependency bumps)
+    - `refactor/...` (internal restructure with no behavior change)
+    - `test/...` (test-only changes)
+    - `perf/...` (performance-only changes)
   - When a new feature starts, create a fresh branch from the latest `main` (or the agreed integration branch). If multiple features run in parallel, keep each on its own branch to avoid entanglement.
   - Keep commits small, reference the relevant tasks/requirements, and separate spec edits from code when practical. Mention both in the commit message when they ship together.
+  - **Scope drift protocol** (when a new, unrelated scope appears mid-branch):
+    1. STOP adding more changes in the new scope.
+    2. Stash the unrelated work (include untracked files): `git stash push -u -m "wip: <new-scope>"`
+       - If only part of your working tree is unrelated, use `git stash push -p` to stash selected hunks.
+    3. Finish the current scope first:
+       - Split into logical commits (spec vs code when practical).
+       - Run the “quad” verification before committing/pushing.
+       - Push and open/update the PR for the current scope.
+    4. Start the new scope on a new branch:
+       - Prefer branching from fresh `origin/main` (`git fetch origin && git checkout -b <type>/<name> origin/main`).
+       - Apply the stash (`git stash pop`) and continue.
+       - If the new work *depends* on unmerged changes from the first branch, branch from that feature branch instead and note the dependency in the PR description.
+    5. If the current branch name no longer matches the delivered scope:
+       - If no PR exists yet, rename locally + remote (`git branch -m ...`, push the new branch, delete the old remote branch).
+       - If a PR already exists, avoid renaming the remote head branch; prefer a follow-up PR/branch with the correct name.
+    6. Update `.specs/<feature>/...` before implementing additional scope (spec-first).
 - **Verification Before Every Commit/Push** (“quadruple check” + simulation):
   1. `npm run lint`
   2. `npm run typecheck`

--- a/script/sync-fork-merge.sh
+++ b/script/sync-fork-merge.sh
@@ -76,7 +76,12 @@ upstream_remote="${UPSTREAM_REMOTE:-upstream}"
 upstream_repo="${UPSTREAM_REPO:-microsoft/vscode-copilot-chat}"
 upstream_branch="${UPSTREAM_BRANCH:-main}"
 fork_repo_slug="${FORK_REPO_SLUG:-}"
-pr_title="${PR_TITLE:-Nightly upstream merge sync}"
+sync_date_utc="$(date -u +%Y-%m-%d)"
+if [[ -z "${PR_TITLE+x}" ]]; then
+	pr_title="Nightly upstream merge sync (${sync_date_utc})"
+else
+	pr_title="${PR_TITLE}"
+fi
 pr_body_header="${PR_BODY:-Automated nightly merge of upstream main into fork main.}"
 pr_reviewer="${PR_REVIEWER:-github-copilot}"
 cleanup_branch="${CLEANUP_BRANCH_ON_MERGE:-1}"


### PR DESCRIPTION
Changes:\n- Nightly upstream merge sync PR titles include UTC date by default.\n- Agent workflow guidance: prefer git worktree for scope drift + path convention.\n\nWhy:\n- Makes merge commits (when using PR title) more readable and searchable, especially for nightly syncs.\n\nVerification:\n- npm run lint\n- npm run typecheck\n- npm run compile\n